### PR TITLE
Phase 2 socket abstraction

### DIFF
--- a/src/IcapClient/IcapClient.php
+++ b/src/IcapClient/IcapClient.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace IcapClient;
 
 use Socket;
+use IcapClient\Socket\SocketClientInterface;
+use IcapClient\Socket\PhpSocketClient;
 use IcapClient\Exception\IcapClientException;
 use IcapClient\Exception\IcapConnectionException;
 use IcapClient\Exception\IcapResponseException;
@@ -18,8 +20,8 @@ class IcapClient
     /** @var int Port number */
     private int $port;
 
-    /** @var ?Socket Socket object */
-    private ?Socket $socket = null;
+    /** @var SocketClientInterface Socket client implementation */
+    private SocketClientInterface $socketClient;
 
     /** @var string User agent string */
     private string $userAgent = 'PHP-ICAP-CLIENT/0.5.0';
@@ -30,10 +32,11 @@ class IcapClient
      * @param string $host IP address of ICAP server
      * @param int $port Port number
      */
-    public function __construct(string $host, int $port)
+    public function __construct(string $host, int $port, SocketClientInterface $socketClient = null)
     {
         $this->host = $host;
         $this->port = $port;
+        $this->socketClient = $socketClient ?? new PhpSocketClient();
     }
 
     /**
@@ -48,16 +51,8 @@ class IcapClient
      */
     private function connect(): bool
     {
-        $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-        if ($this->socket === false) {
-            throw new IcapConnectionException('Failed to create socket.');
-        }
-
-        if (!socket_connect($this->socket, $this->host, $this->port)) {
-            // Get detailed error message for better diagnostics
-            $errorMessage = socket_strerror(socket_last_error($this->socket));
-            socket_close($this->socket);
-            $this->socket = null;
+        if (!$this->socketClient->connect($this->host, $this->port)) {
+            $errorMessage = socket_strerror($this->socketClient->getLastError());
             throw new IcapConnectionException(
                 "Cannot connect to icap://{$this->host}:{$this->port} (Socket error: {$errorMessage})"
             );
@@ -71,11 +66,7 @@ class IcapClient
      */
     private function disconnect(): void
     {
-        if ($this->socket instanceof Socket) { // Check if socket is valid before shutdown/close 
-            socket_shutdown($this->socket);
-            socket_close($this->socket);
-        }
-        $this->socket = null; // Reset socket property 
+        $this->socketClient->disconnect();
     }
 
     /**
@@ -85,7 +76,7 @@ class IcapClient
      */
     public function getLastSocketError(): int
     {
-        return socket_last_error($this->socket);
+        return $this->socketClient->getLastError();
     }
 
     /**
@@ -240,10 +231,10 @@ class IcapClient
         // connect() now throws a specific connection exception with more detail
         $this->connect();
 
-        socket_write($this->socket, $request);
+        $this->socketClient->write($request);
 
         $response = '';
-        while ($buffer = socket_read($this->socket, 2048)) {
+        while ($buffer = $this->socketClient->read(2048)) {
             $response .= $buffer;
         }
 

--- a/src/IcapClient/Socket/PhpSocketClient.php
+++ b/src/IcapClient/Socket/PhpSocketClient.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace IcapClient\Socket;
+
+use Socket;
+
+class PhpSocketClient implements SocketClientInterface
+{
+    private ?Socket $socket = null;
+
+    public function connect(string $host, int $port): bool
+    {
+        $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        if ($this->socket === false) {
+            return false;
+        }
+
+        if (!socket_connect($this->socket, $host, $port)) {
+            $this->disconnect();
+            return false;
+        }
+
+        return true;
+    }
+
+    public function write(string $data): int
+    {
+        if (!$this->socket instanceof Socket) {
+            return 0;
+        }
+
+        return socket_write($this->socket, $data);
+    }
+
+    public function read(int $length): string
+    {
+        if (!$this->socket instanceof Socket) {
+            return '';
+        }
+
+        return socket_read($this->socket, $length);
+    }
+
+    public function disconnect(): void
+    {
+        if ($this->socket instanceof Socket) {
+            socket_shutdown($this->socket);
+            socket_close($this->socket);
+        }
+        $this->socket = null;
+    }
+
+    public function getLastError(): int
+    {
+        return socket_last_error($this->socket);
+    }
+}

--- a/src/IcapClient/Socket/SocketClientInterface.php
+++ b/src/IcapClient/Socket/SocketClientInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace IcapClient\Socket;
+
+interface SocketClientInterface
+{
+    public function connect(string $host, int $port): bool;
+
+    public function write(string $data): int;
+
+    public function read(int $length): string;
+
+    public function disconnect(): void;
+
+    public function getLastError(): int;
+}

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -1,13 +1,14 @@
 <?php
 
 use IcapClient\IcapClient;
+use IcapClient\Socket\PhpSocketClient;
 use PHPUnit\Framework\TestCase;
 
 class IcapClientTest extends TestCase
 {
     public function testGetRequest()
     {
-        $client = new IcapClient('icap.test', 1344);
+        $client = new IcapClient('icap.test', 1344, new PhpSocketClient());
         $body = [
             'res-hdr' => "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n",
             'res-body' => 'This is a test.'
@@ -39,7 +40,7 @@ class IcapClientTest extends TestCase
             "\r\n" .
             "f\r\nThis is a test.\r\n0\r\n\r\n";
 
-        $client = new IcapClient('icap.test', 1344);
+        $client = new IcapClient('icap.test', 1344, new PhpSocketClient());
         $ref = new ReflectionClass($client);
         $method = $ref->getMethod('parseResponse');
         $method->setAccessible(true);

--- a/tests/PhpSocketClientTest.php
+++ b/tests/PhpSocketClientTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use IcapClient\Socket\PhpSocketClient;
+use PHPUnit\Framework\TestCase;
+
+class PhpSocketClientTest extends TestCase
+{
+    public function testConnectWriteReadDisconnect()
+    {
+        if (!function_exists('socket_create')) {
+            $this->markTestSkipped('Sockets extension not available');
+        }
+
+        // create server socket
+        $server = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        socket_bind($server, '127.0.0.1', 0);
+        socket_getsockname($server, $address, $port);
+        socket_listen($server, 1);
+
+        $client = new PhpSocketClient();
+        $this->assertTrue($client->connect($address, $port));
+
+        $peer = socket_accept($server);
+
+        $client->write('hello');
+        $this->assertSame('hello', socket_read($peer, 5));
+
+        socket_write($peer, 'world');
+        $this->assertSame('world', $client->read(5));
+
+        $client->disconnect();
+        socket_close($peer);
+        socket_close($server);
+
+        $this->assertIsInt($client->getLastError());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SocketClientInterface` and `PhpSocketClient` implementation
- refactor `IcapClient` to use injected `SocketClientInterface`
- update `IcapClientTest` for new constructor
- add tests for `PhpSocketClient`

## Testing
- `phpunit --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f45413ad8832ebd8b91d0c1635dc8