### PR TITLE
Introduce request formatter and response parser

### DIFF
--- a/src/IcapClient/DTO/IcapRequest.php
+++ b/src/IcapClient/DTO/IcapRequest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace IcapClient\DTO;
+
+class IcapRequest
+{
+    public string $method;
+    public string $host;
+    public string $service;
+    /** @var array<string,string> */
+    public array $headers;
+    /** @var array<string,string> */
+    public array $body;
+
+    public function __construct(string $method, string $host, string $service, array $headers = [], array $body = [])
+    {
+        $this->method = $method;
+        $this->host = $host;
+        $this->service = $service;
+        $this->headers = $headers;
+        $this->body = $body;
+    }
+}

--- a/src/IcapClient/DTO/IcapResponse.php
+++ b/src/IcapClient/DTO/IcapResponse.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace IcapClient\DTO;
+
+class IcapResponse
+{
+    /** @var array<string,string> */
+    public array $protocol;
+    /** @var array<string,string> */
+    public array $headers;
+    /** @var array<string,string> */
+    public array $body;
+    public string $rawBody;
+
+    public function __construct(array $protocol = [], array $headers = [], array $body = [], string $rawBody = '')
+    {
+        $this->protocol = $protocol;
+        $this->headers = $headers;
+        $this->body = $body;
+        $this->rawBody = $rawBody;
+    }
+}

--- a/src/IcapClient/IcapClient.php
+++ b/src/IcapClient/IcapClient.php
@@ -3,13 +3,16 @@ declare(strict_types=1);
 
 namespace IcapClient;
 
-use Socket;
 use IcapClient\Socket\SocketClientInterface;
 use IcapClient\Socket\PhpSocketClient;
 use IcapClient\Exception\IcapClientException;
 use IcapClient\Exception\IcapConnectionException;
 use IcapClient\Exception\IcapResponseException;
 use IcapClient\IcapProtocolConstants;
+use IcapClient\DTO\IcapRequest;
+use IcapClient\DTO\IcapResponse;
+use IcapClient\IcapRequestFormatter;
+use IcapClient\IcapResponseParser;
 
 class IcapClient
 {
@@ -23,6 +26,12 @@ class IcapClient
     /** @var SocketClientInterface Socket client implementation */
     private SocketClientInterface $socketClient;
 
+    /** @var IcapRequestFormatter */
+    private IcapRequestFormatter $requestFormatter;
+
+    /** @var IcapResponseParser */
+    private IcapResponseParser $responseParser;
+
     /** @var string User agent string */
     private string $userAgent = 'PHP-ICAP-CLIENT/0.5.0';
 
@@ -32,11 +41,19 @@ class IcapClient
      * @param string $host IP address of ICAP server
      * @param int $port Port number
      */
-    public function __construct(string $host, int $port, SocketClientInterface $socketClient = null)
+    public function __construct(
+        string $host,
+        int $port,
+        SocketClientInterface $socketClient = null,
+        IcapRequestFormatter $requestFormatter = null,
+        IcapResponseParser $responseParser = null
+    )
     {
         $this->host = $host;
         $this->port = $port;
         $this->socketClient = $socketClient ?? new PhpSocketClient();
+        $this->requestFormatter = $requestFormatter ?? new IcapRequestFormatter();
+        $this->responseParser = $responseParser ?? new IcapResponseParser();
     }
 
     /**
@@ -111,63 +128,9 @@ class IcapClient
      */
     public function getRequest(string $method, string $service, array $body = [], array $headers = []): string
     {
-        if (!array_key_exists(IcapProtocolConstants::HEADER_HOST, $headers)) {
-            $headers[IcapProtocolConstants::HEADER_HOST] = $this->host;
-        }
+        $icapRequest = new IcapRequest($method, $this->host, $service, $headers, $body);
 
-        if (!array_key_exists(IcapProtocolConstants::HEADER_USER_AGENT, $headers)) {
-            $headers[IcapProtocolConstants::HEADER_USER_AGENT] = $this->userAgent;
-        }
-
-        if (!array_key_exists(IcapProtocolConstants::HEADER_CONNECTION, $headers)) {
-            $headers[IcapProtocolConstants::HEADER_CONNECTION] = 'close';
-        }
-
-        $bodyData = '';
-        $hasBody = false;
-        $encapsulated = [];
-        foreach ($body as $type => $data) {
-            switch ($type) {
-                case IcapProtocolConstants::SECTION_REQ_HDR:
-                case IcapProtocolConstants::SECTION_RES_HDR:
-                    $encapsulated[$type] = strlen($bodyData);
-                    $bodyData .= $data;
-                    break;
-
-                case IcapProtocolConstants::SECTION_REQ_BODY:
-                case IcapProtocolConstants::SECTION_RES_BODY:
-                    $encapsulated[$type] = strlen($bodyData);
-                    $bodyData .= dechex(strlen($data)) . "\r\n";
-                    $bodyData .= $data;
-                    $bodyData .= "\r\n";
-                    $hasBody = true;
-                    break;
-            }
-        }
-
-        if ($hasBody) {
-            $bodyData .= "0\r\n\r\n";
-        } elseif (count($encapsulated) > 0) {
-            $encapsulated[IcapProtocolConstants::SECTION_NULL_BODY] = strlen($bodyData);
-        }
-
-        if (count($encapsulated) > 0) {
-            $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] = '';
-            foreach ($encapsulated as $section => $offset) {
-                $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] .= $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] === '' ? '' : ', ';
-                $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] .= "{$section}={$offset}";
-            }
-        }
-
-        $request = "{$method} icap://{$this->host}/{$service} " . IcapProtocolConstants::PROTOCOL_PREFIX . IcapProtocolConstants::PROTOCOL_VERSION . "\r\n";
-        foreach ($headers as $header => $value) {
-            $request .= "{$header}: {$value}\r\n";
-        }
-
-        $request .= "\r\n";
-        $request .= $bodyData;
-
-        return $request;
+        return $this->requestFormatter->format($icapRequest);
     }
 
     /**
@@ -251,79 +214,13 @@ class IcapClient
      */
     private function parseResponse(string $response): array
     {
-        $responseArray = [
-            'protocol' => [],
-            'headers' => [],
-            'body' => [],
-            'rawBody' => ''
+        $parsed = $this->responseParser->parse($response);
+
+        return [
+            'protocol' => $parsed->protocol,
+            'headers' => $parsed->headers,
+            'body' => $parsed->body,
+            'rawBody' => $parsed->rawBody,
         ];
-        foreach (preg_split('/\r?\n/', $response) as $line) {
-            if ([] === $responseArray['protocol']) {
-                if (0 !== strpos($line, IcapProtocolConstants::PROTOCOL_PREFIX)) {
-                    throw new IcapResponseException('Unknown ICAP response');
-                }
-
-                $parts = preg_split('/\ +/', $line, 3);
-                $responseArray['protocol'] = [
-                    'icap' => isset($parts[0]) ?
-                        $parts[0] : '',
-                    'code' => isset($parts[1]) ?
-                        $parts[1] : '',
-                    'message' => isset($parts[2]) ?
-                        $parts[2] : '',
-                ];
-                continue;
-            }
-
-            if ('' === $line) {
-                break;
-            }
-
-            $parts = preg_split('/:\ /', $line, 2);
-            if (isset($parts[0])) {
-                $responseArray['headers'][$parts[0]] = isset($parts[1]) ?
-                    $parts[1] : '';
-            }
-        }
-
-        $body = preg_split('/\r?\n\r?\n/', $response, 2);
-        if (isset($body[1])) {
-            $responseArray['rawBody'] = $body[1];
-            if (array_key_exists(IcapProtocolConstants::HEADER_ENCAPSULATED, $responseArray['headers'])) {
-                $encapsulated = [];
-                $params = preg_split('/, /', $responseArray['headers'][IcapProtocolConstants::HEADER_ENCAPSULATED]);
-
-                if (count($params) > 0) {
-                    foreach ($params as $param) {
-                        $parts = preg_split('/=/', $param);
-                        if (count($parts) !== 2) {
-                            continue;
-                        }
-
-                        $encapsulated[$parts[0]] = $parts[1];
-                    }
-                }
-
-                foreach ($encapsulated as $section => $offset) {
-                    $data = substr($body[1], (int)$offset);
-                    switch ($section) {
-                        case IcapProtocolConstants::SECTION_REQ_HDR:
-                        case IcapProtocolConstants::SECTION_RES_HDR:
-                            $responseArray['body'][$section] = preg_split('/\r?\n\r?\n/', $data, 2)[0];
-                            break;
-
-                        case IcapProtocolConstants::SECTION_REQ_BODY:
-                        case IcapProtocolConstants::SECTION_RES_BODY:
-                            $parts = preg_split('/\r?\n/', $data, 2);
-                            if (count($parts) === 2) {
-                                $responseArray['body'][$section] = substr($parts[1], 0, hexdec($parts[0]));
-                            }
-                            break;
-                    }
-                }
-            }
-        }
-
-        return $responseArray;
     }
 }

--- a/src/IcapClient/IcapRequestFormatter.php
+++ b/src/IcapClient/IcapRequestFormatter.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace IcapClient;
+
+use IcapClient\DTO\IcapRequest;
+
+class IcapRequestFormatter
+{
+    public function format(IcapRequest $request): string
+    {
+        $headers = $request->headers;
+
+        if (!array_key_exists(IcapProtocolConstants::HEADER_HOST, $headers)) {
+            $headers[IcapProtocolConstants::HEADER_HOST] = $request->host;
+        }
+        if (!array_key_exists(IcapProtocolConstants::HEADER_USER_AGENT, $headers)) {
+            $headers[IcapProtocolConstants::HEADER_USER_AGENT] = 'PHP-ICAP-CLIENT/0.5.0';
+        }
+        if (!array_key_exists(IcapProtocolConstants::HEADER_CONNECTION, $headers)) {
+            $headers[IcapProtocolConstants::HEADER_CONNECTION] = 'close';
+        }
+
+        $bodyData = '';
+        $hasBody = false;
+        $encapsulated = [];
+        foreach ($request->body as $type => $data) {
+            switch ($type) {
+                case IcapProtocolConstants::SECTION_REQ_HDR:
+                case IcapProtocolConstants::SECTION_RES_HDR:
+                    $encapsulated[$type] = strlen($bodyData);
+                    $bodyData .= $data;
+                    break;
+                case IcapProtocolConstants::SECTION_REQ_BODY:
+                case IcapProtocolConstants::SECTION_RES_BODY:
+                    $encapsulated[$type] = strlen($bodyData);
+                    $bodyData .= dechex(strlen($data)) . "\r\n";
+                    $bodyData .= $data;
+                    $bodyData .= "\r\n";
+                    $hasBody = true;
+                    break;
+            }
+        }
+
+        if ($hasBody) {
+            $bodyData .= "0\r\n\r\n";
+        } elseif (count($encapsulated) > 0) {
+            $encapsulated[IcapProtocolConstants::SECTION_NULL_BODY] = strlen($bodyData);
+        }
+
+        if (count($encapsulated) > 0) {
+            $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] = '';
+            foreach ($encapsulated as $section => $offset) {
+                $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] .= $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] === '' ? '' : ', ';
+                $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] .= "{$section}={$offset}";
+            }
+        }
+
+        $result = "{$request->method} icap://{$request->host}/{$request->service} " .
+            IcapProtocolConstants::PROTOCOL_PREFIX . IcapProtocolConstants::PROTOCOL_VERSION . "\r\n";
+        foreach ($headers as $header => $value) {
+            $result .= "{$header}: {$value}\r\n";
+        }
+
+        $result .= "\r\n";
+        $result .= $bodyData;
+
+        return $result;
+    }
+}

--- a/src/IcapClient/IcapResponseParser.php
+++ b/src/IcapClient/IcapResponseParser.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace IcapClient;
+
+use IcapClient\DTO\IcapResponse;
+use IcapClient\Exception\IcapResponseException;
+
+class IcapResponseParser
+{
+    public function parse(string $response): IcapResponse
+    {
+        $result = new IcapResponse();
+
+        foreach (preg_split('/\r?\n/', $response) as $line) {
+            if ([] === $result->protocol) {
+                if (0 !== strpos($line, IcapProtocolConstants::PROTOCOL_PREFIX)) {
+                    throw new IcapResponseException('Unknown ICAP response');
+                }
+                $parts = preg_split('/\ +/', $line, 3);
+                $result->protocol = [
+                    'icap' => $parts[0] ?? '',
+                    'code' => $parts[1] ?? '',
+                    'message' => $parts[2] ?? '',
+                ];
+                continue;
+            }
+
+            if ('' === $line) {
+                break;
+            }
+
+            $parts = preg_split('/:\ /', $line, 2);
+            if (isset($parts[0])) {
+                $result->headers[$parts[0]] = $parts[1] ?? '';
+            }
+        }
+
+        $body = preg_split('/\r?\n\r?\n/', $response, 2);
+        if (isset($body[1])) {
+            $result->rawBody = $body[1];
+            if (array_key_exists(IcapProtocolConstants::HEADER_ENCAPSULATED, $result->headers)) {
+                $encapsulated = [];
+                $params = preg_split('/, /', $result->headers[IcapProtocolConstants::HEADER_ENCAPSULATED]);
+                if (count($params) > 0) {
+                    foreach ($params as $param) {
+                        $parts = preg_split('/=/', $param);
+                        if (count($parts) !== 2) {
+                            continue;
+                        }
+                        $encapsulated[$parts[0]] = $parts[1];
+                    }
+                }
+                foreach ($encapsulated as $section => $offset) {
+                    $data = substr($body[1], (int)$offset);
+                    switch ($section) {
+                        case IcapProtocolConstants::SECTION_REQ_HDR:
+                        case IcapProtocolConstants::SECTION_RES_HDR:
+                            $result->body[$section] = preg_split('/\r?\n\r?\n/', $data, 2)[0];
+                            break;
+                        case IcapProtocolConstants::SECTION_REQ_BODY:
+                        case IcapProtocolConstants::SECTION_RES_BODY:
+                            $parts = preg_split('/\r?\n/', $data, 2);
+                            if (count($parts) === 2) {
+                                $result->body[$section] = substr($parts[1], 0, hexdec($parts[0]));
+                            }
+                            break;
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/IcapRequestFormatterTest.php
+++ b/tests/IcapRequestFormatterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use IcapClient\DTO\IcapRequest;
+use IcapClient\IcapRequestFormatter;
+use PHPUnit\Framework\TestCase;
+
+class IcapRequestFormatterTest extends TestCase
+{
+    public function testFormat()
+    {
+        $request = new IcapRequest(
+            'RESPMOD',
+            'icap.test',
+            'example',
+            [],
+            [
+                'res-hdr' => "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n",
+                'res-body' => 'This is a test.'
+            ]
+        );
+
+        $formatter = new IcapRequestFormatter();
+        $result = $formatter->format($request);
+
+        $expected = "RESPMOD icap://icap.test/example ICAP/1.0\r\n" .
+            "Host: icap.test\r\n" .
+            "User-Agent: PHP-ICAP-CLIENT/0.5.0\r\n" .
+            "Connection: close\r\n" .
+            "Encapsulated: res-hdr=0, res-body=64\r\n" .
+            "\r\n" .
+            "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n" .
+            "f\r\nThis is a test.\r\n0\r\n\r\n";
+
+        $this->assertSame($expected, $result);
+    }
+}

--- a/tests/IcapResponseParserTest.php
+++ b/tests/IcapResponseParserTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use IcapClient\IcapResponseParser;
+use PHPUnit\Framework\TestCase;
+
+class IcapResponseParserTest extends TestCase
+{
+    public function testParse()
+    {
+        $response = "ICAP/1.0 200 OK\r\n" .
+            "Date: Wed, 03 Jul 2019 22:11:33 GMT\r\n" .
+            "ISTag: testtag\r\n" .
+            "Encapsulated: res-hdr=0, res-body=64\r\n" .
+            "Server: Python-ICAP/1.0\r\n" .
+            "\r\n" .
+            "HTTP/1.1 200 OK\r\n" .
+            "content-type: text/html\r\n" .
+            "server: Test/0.0.1\r\n" .
+            "\r\n" .
+            "f\r\nThis is a test.\r\n0\r\n\r\n";
+
+        $parser = new IcapResponseParser();
+        $result = $parser->parse($response);
+
+        $expected = [
+            'protocol' => [
+                'icap' => 'ICAP/1.0',
+                'code' => '200',
+                'message' => 'OK',
+            ],
+            'headers' => [
+                'Date' => 'Wed, 03 Jul 2019 22:11:33 GMT',
+                'ISTag' => 'testtag',
+                'Encapsulated' => 'res-hdr=0, res-body=64',
+                'Server' => 'Python-ICAP/1.0',
+            ],
+            'body' => [
+                'res-hdr' => "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\nserver: Test/0.0.1",
+                'res-body' => 'This is a test.',
+            ],
+            'rawBody' => "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\nserver: Test/0.0.1\r\nf\r\nThis is a test.\r\n0\r\n\r\n",
+        ];
+
+        $this->assertEquals($expected, [
+            'protocol' => $result->protocol,
+            'headers' => $result->headers,
+            'body' => $result->body,
+            'rawBody' => $result->rawBody,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- extract DTO classes for ICAP requests/responses
- add `IcapRequestFormatter` and `IcapResponseParser`
- update `IcapClient` to use these helpers
- cover formatter and parser with unit tests

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684faa6ad0dc832e8c44c499873b6df9