### PR TITLE
Fix header injection and add stream handling

### DIFF
--- a/src/IcapClient/DTO/IcapRequest.php
+++ b/src/IcapClient/DTO/IcapRequest.php
@@ -13,7 +13,7 @@ class IcapRequest
     public string $service;
     /** @var array<string,string> */
     public array $headers;
-    /** @var array<string,string> */
+    /** @var array<string,string|resource> */
     public array $body;
 
     /**
@@ -21,7 +21,7 @@ class IcapRequest
      * @param string $host    Target host
      * @param string $service Service name
      * @param array<string,string> $headers Additional headers
-     * @param array<string,string> $body    Encapsulated body sections
+     * @param array<string,string|resource> $body    Encapsulated body sections
      */
     public function __construct(string $method, string $host, string $service, array $headers = [], array $body = [])
     {

--- a/src/IcapClient/Exception/IcapFileException.php
+++ b/src/IcapClient/Exception/IcapFileException.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace IcapClient\Exception;
+
+/**
+ * Thrown when a file or stream cannot be read.
+ */
+class IcapFileException extends IcapClientException
+{
+}

--- a/src/IcapClient/IcapClient.php
+++ b/src/IcapClient/IcapClient.php
@@ -8,6 +8,7 @@ use IcapClient\Socket\PhpSocketClient;
 use IcapClient\Exception\IcapClientException;
 use IcapClient\Exception\IcapConnectionException;
 use IcapClient\Exception\IcapResponseException;
+use IcapClient\Exception\IcapFileException;
 use IcapClient\IcapProtocolConstants;
 use IcapClient\DTO\IcapRequest;
 use IcapClient\DTO\IcapResponse;
@@ -37,6 +38,12 @@ class IcapClient
 
     /** @var string User agent string */
     private string $userAgent = 'PHP-ICAP-CLIENT/0.5.0';
+
+    /** @var bool Keep the socket connection open between requests */
+    private bool $persistentConnection = false;
+
+    /** @var bool Connection state */
+    private bool $connected = false;
 
     /**
      * Constructor
@@ -71,6 +78,10 @@ class IcapClient
      */
     private function connect(): bool
     {
+        if ($this->connected) {
+            return true;
+        }
+
         if (!$this->socketClient->connect($this->host, $this->port)) {
             $errorMessage = socket_strerror($this->socketClient->getLastError());
             throw new IcapConnectionException(
@@ -78,15 +89,17 @@ class IcapClient
             );
         }
 
+        $this->connected = true;
         return true;
     }
 
     /**
      * Close connection to ICAP server
      */
-    private function disconnect(): void
+    public function disconnect(): void
     {
         $this->socketClient->disconnect();
+        $this->connected = false;
     }
 
     /**
@@ -118,6 +131,37 @@ class IcapClient
     public function setUserAgent(string $userAgent): void
     {
         $this->userAgent = $userAgent;
+    }
+
+    /**
+     * Enable or disable persistent connections.
+     */
+    public function setPersistentConnection(bool $persistent): void
+    {
+        $this->persistentConnection = $persistent;
+    }
+
+    /**
+     * Check if persistent connections are enabled.
+     */
+    public function isPersistentConnection(): bool
+    {
+        return $this->persistentConnection;
+    }
+
+    /**
+     * Read the contents of a file and throw an exception on failure.
+     *
+     * @throws IcapFileException
+     */
+    protected function readFile(string $filename): string
+    {
+        $data = @file_get_contents($filename);
+        if ($data === false) {
+            throw new Exception\IcapFileException("Unable to read file: {$filename}");
+        }
+
+        return $data;
     }
 
     /**
@@ -204,7 +248,9 @@ class IcapClient
             $response .= $buffer;
         }
 
-        $this->disconnect();
+        if (!$this->persistentConnection) {
+            $this->disconnect();
+        }
         return $response;
     }
 

--- a/src/IcapClient/IcapRequestFormatter.php
+++ b/src/IcapClient/IcapRequestFormatter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace IcapClient;
 
 use IcapClient\DTO\IcapRequest;
+use IcapClient\Exception\IcapFileException;
 
 /**
  * Converts {@link IcapRequest} objects into raw ICAP request strings.
@@ -35,13 +36,29 @@ class IcapRequestFormatter
                 case IcapProtocolConstants::SECTION_REQ_HDR:
                 case IcapProtocolConstants::SECTION_RES_HDR:
                     $encapsulated[$type] = strlen($bodyData);
-                    $bodyData .= $data;
+                    if (is_resource($data)) {
+                        $content = stream_get_contents($data);
+                        if ($content === false) {
+                            throw new Exception\IcapFileException('Unable to read body stream');
+                        }
+                    } else {
+                        $content = $data;
+                    }
+                    $bodyData .= $content;
                     break;
                 case IcapProtocolConstants::SECTION_REQ_BODY:
                 case IcapProtocolConstants::SECTION_RES_BODY:
+                    if (is_resource($data)) {
+                        $content = stream_get_contents($data);
+                        if ($content === false) {
+                            throw new Exception\IcapFileException('Unable to read body stream');
+                        }
+                    } else {
+                        $content = $data;
+                    }
                     $encapsulated[$type] = strlen($bodyData);
-                    $bodyData .= dechex(strlen($data)) . "\r\n";
-                    $bodyData .= $data;
+                    $bodyData .= dechex(strlen($content)) . "\r\n";
+                    $bodyData .= $content;
                     $bodyData .= "\r\n";
                     $hasBody = true;
                     break;
@@ -65,7 +82,8 @@ class IcapRequestFormatter
         $result = "{$request->method} icap://{$request->host}/{$request->service} " .
             IcapProtocolConstants::PROTOCOL_PREFIX . IcapProtocolConstants::PROTOCOL_VERSION . "\r\n";
         foreach ($headers as $header => $value) {
-            $result .= "{$header}: {$value}\r\n";
+            $sanitizedValue = str_replace(["\r", "\n"], '', $value);
+            $result .= "{$header}: {$sanitizedValue}\r\n";
         }
 
         $result .= "\r\n";

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -67,4 +67,15 @@ class IcapClientTest extends TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function testReadFileThrowsException()
+    {
+        $client = new IcapClient('icap.test', 1344, new PhpSocketClient());
+        $ref = new ReflectionClass($client);
+        $method = $ref->getMethod('readFile');
+        $method->setAccessible(true);
+
+        $this->expectException(IcapClient\Exception\IcapFileException::class);
+        $method->invoke($client, '/does/not/exist');
+    }
 }

--- a/tests/IcapRequestFormatterTest.php
+++ b/tests/IcapRequestFormatterTest.php
@@ -33,4 +33,22 @@ class IcapRequestFormatterTest extends TestCase
 
         $this->assertSame($expected, $result);
     }
+
+    public function testHeaderInjectionIsPrevented()
+    {
+        $request = new IcapRequest(
+            'OPTIONS',
+            'icap.test',
+            'example',
+            [
+                'X-Test' => "foo\r\nInjected: bar"
+            ]
+        );
+
+        $formatter = new IcapRequestFormatter();
+        $result = $formatter->format($request);
+
+        $this->assertStringContainsString("X-Test: fooInjected: bar\r\n", $result);
+        $this->assertStringNotContainsString("\nInjected:", $result);
+    }
 }


### PR DESCRIPTION
## Summary
- sanitize header values when formatting requests
- support resources as body data in formatter
- add persistent connection options and file error handling
- implement `IcapFileException`
- test header injection and file read errors

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdeb1ce64832eb491af06552cf224