### PR TITLE
Set PHP 7.4 as minimum requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,54 @@
 # php-icap-client
 
-PHP ICAP client.
+This project is a fork of [nathan242/php-icap-client](https://github.com/nathan242/php-icap-client) originally created by **Nathan Patrizi**. The code base has been thoroughly modernised and hardened to provide a safer ICAP client library for contemporary PHP projects. Full credit goes to Nathan for laying the foundation.
 
-Allows you to send requests to Internet Content Adaptation Protocol (ICAP) servers from PHP.
+## Overview
 
-### Usage
+The library offers a simple way to interact with Internet Content Adaptation Protocol (ICAP) services from PHP. It includes helpers for crafting requests and parsing responses while keeping the socket layer pluggable.
 
-Instantiate the class with the ICAP server address and port:
+## Requirements
+
+- PHP **7.4** or newer
+- Composer for installing dependencies
+
+## Installation
+
+```
+composer require nathan242/php-icap-client
+```
+
+## Basic Usage
 
 ```php
+use IcapClient\IcapClient;
+
 $icap = new IcapClient('127.0.0.1', 13440);
+$result = $icap->options('example');
+print_r($result);
 ```
 
-Send an OPTIONS request to the "example" service:
+`reqmod` and `respmod` helpers are also available for modifying requests and responses:
 
 ```php
-$icap->options('example');
+$icap->reqmod('example', [
+    'req-hdr'  => "POST /test HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+    'req-body' => 'This is another test.'
+]);
+
+$icap->respmod('example', [
+    'res-hdr'  => "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n",
+    'res-body' => 'This is a test.'
+]);
 ```
 
-Send a REQMOD and RESPMOD request to the "example" service:
+## Architecture
 
-```php
-$icap->reqmod(
-    'example',
-    [
-        'req-hdr' => "POST /test HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
-        'req-body' => 'This is another test.'
-    ]
-);
+- **IcapClient** – high-level API that uses the formatter, parser and socket implementation.
+- **IcapRequestFormatter** – turns request objects into raw ICAP strings.
+- **IcapResponseParser** – parses server responses into structured objects.
+- **Socket\*** – pluggable socket layer so you can provide your own transport.
+- Data transfer objects can be found under the `DTO` namespace.
 
-$icap->respmod(
-    'example',
-    [
-        'res-hdr' => "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n",
-        'res-body' => 'This is a test.'
-    ]
-);
-```
+## License
 
-Successful requests will return an array describing the response:
-
-```
-Array
-(
-    [protocol] => Array
-        (
-            [icap] => ICAP/1.0
-            [code] => 200
-            [message] => OK
-        )
-
-    [headers] => Array
-        (
-            [Date] => Wed, 03 Jul 2019 22:11:33 GMT
-            [ISTag] => X7K07GDZQW702ZVLSG6WWO0EPE2CTOMR
-            [Encapsulated] => res-hdr=0, res-body=64
-            [Server] => ICAP/1.3 Python/2.7.3
-        )
-
-    [body] => Array
-        (
-            [res-hdr] => HTTP/1.1 200 OK
-content-type: text/html
-server: Test/0.0.1
-            [res-body] => This is a test.
-        )
-
-    [rawBody] => HTTP/1.1 200 OK
-content-type: text/html
-server: Test/0.0.1
-
-f
-This is a test.
-0
-
-
-)
-```
-
-### Architecture overview
-
-The library is organised into small components:
-
-* **IcapClient** – high-level API combining the formatter, parser and socket implementation.
-* **IcapRequestFormatter** – turns request objects into raw ICAP strings.
-* **IcapResponseParser** – parses server responses into structured objects.
-* **Socket\*** – pluggable socket layer used by `IcapClient` to communicate with the server.
-
-Data transfer objects under `DTO` hold the request and response data structures.
-
+Released under the MIT license. See `LICENSE` for details.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
## Summary
- require PHP 7.4 in `composer.json`
- completely rewrite the README

## Testing
- `php -v` *(fails: command not found)*
- `composer --version` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684fe22b9228832e8f04fc536cb173e4