### PR TITLE
Add configurable socket timeouts

### DIFF
--- a/src/IcapClient/Socket/PhpSocketClient.php
+++ b/src/IcapClient/Socket/PhpSocketClient.php
@@ -12,6 +12,16 @@ class PhpSocketClient implements SocketClientInterface
 {
     private ?Socket $socket = null;
 
+    private float $readTimeout;
+
+    private float $writeTimeout;
+
+    public function __construct(float $readTimeout = 0.0, float $writeTimeout = 0.0)
+    {
+        $this->readTimeout = $readTimeout;
+        $this->writeTimeout = $writeTimeout;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -21,6 +31,25 @@ class PhpSocketClient implements SocketClientInterface
         if ($this->socket === false) {
             return false;
         }
+
+        socket_set_option(
+            $this->socket,
+            SOL_SOCKET,
+            SO_RCVTIMEO,
+            [
+                'sec' => (int) $this->readTimeout,
+                'usec' => (int) (($this->readTimeout - (int) $this->readTimeout) * 1_000_000),
+            ]
+        );
+        socket_set_option(
+            $this->socket,
+            SOL_SOCKET,
+            SO_SNDTIMEO,
+            [
+                'sec' => (int) $this->writeTimeout,
+                'usec' => (int) (($this->writeTimeout - (int) $this->writeTimeout) * 1_000_000),
+            ]
+        );
 
         if (!socket_connect($this->socket, $host, $port)) {
             $this->disconnect();
@@ -72,5 +101,47 @@ class PhpSocketClient implements SocketClientInterface
     public function getLastError(): int
     {
         return socket_last_error($this->socket);
+    }
+
+    public function setReadTimeout(float $timeout): void
+    {
+        $this->readTimeout = $timeout;
+        if ($this->socket instanceof Socket) {
+            socket_set_option(
+                $this->socket,
+                SOL_SOCKET,
+                SO_RCVTIMEO,
+                [
+                    'sec' => (int) $timeout,
+                    'usec' => (int) (($timeout - (int) $timeout) * 1_000_000),
+                ]
+            );
+        }
+    }
+
+    public function getReadTimeout(): float
+    {
+        return $this->readTimeout;
+    }
+
+    public function setWriteTimeout(float $timeout): void
+    {
+        $this->writeTimeout = $timeout;
+        if ($this->socket instanceof Socket) {
+            socket_set_option(
+                $this->socket,
+                SOL_SOCKET,
+                SO_SNDTIMEO,
+                [
+                    'sec' => (int) $timeout,
+                    'usec' => (int) (($timeout - (int) $timeout) * 1_000_000),
+                ]
+            );
+        }
+    }
+
+    public function getWriteTimeout(): float
+    {
+        return $this->writeTimeout;
     }
 }

--- a/src/IcapClient/Socket/SocketClientInterface.php
+++ b/src/IcapClient/Socket/SocketClientInterface.php
@@ -32,4 +32,24 @@ interface SocketClientInterface
      * Return the last socket error code.
      */
     public function getLastError(): int;
+
+    /**
+     * Set read timeout in seconds.
+     */
+    public function setReadTimeout(float $timeout): void;
+
+    /**
+     * Get read timeout in seconds.
+     */
+    public function getReadTimeout(): float;
+
+    /**
+     * Set write timeout in seconds.
+     */
+    public function setWriteTimeout(float $timeout): void;
+
+    /**
+     * Get write timeout in seconds.
+     */
+    public function getWriteTimeout(): float;
 }

--- a/tests/PhpSocketClientTest.php
+++ b/tests/PhpSocketClientTest.php
@@ -34,4 +34,17 @@ class PhpSocketClientTest extends TestCase
 
         $this->assertIsInt($client->getLastError());
     }
+
+    public function testTimeoutConfiguration()
+    {
+        $client = new PhpSocketClient(1.5, 2.5);
+        $this->assertSame(1.5, $client->getReadTimeout());
+        $this->assertSame(2.5, $client->getWriteTimeout());
+
+        $client->setReadTimeout(3.0);
+        $this->assertSame(3.0, $client->getReadTimeout());
+
+        $client->setWriteTimeout(4.0);
+        $this->assertSame(4.0, $client->getWriteTimeout());
+    }
 }


### PR DESCRIPTION
## Summary
- extend `SocketClientInterface` with read/write timeout configuration
- implement timeout handling in `PhpSocketClient`
- expose constructor and setters for timeout configuration
- test new timeout methods

## Testing
- `phpunit` *(fails: command not found)*
