### PR TITLE
Add optional streaming for large bodies

### DIFF
--- a/src/IcapClient/IcapClient.php
+++ b/src/IcapClient/IcapClient.php
@@ -219,6 +219,17 @@ class IcapClient
     }
 
     /**
+     * Generate request data as an iterable. Body sections provided as
+     * {@see \Generator} or iterable will be streamed when sending.
+     */
+    public function getRequestIterable(string $method, string $service, array $body = [], array $headers = []): iterable
+    {
+        $icapRequest = new IcapRequest($method, $this->host, $service, $headers, $body);
+
+        return $this->requestFormatter->formatIterable($icapRequest);
+    }
+
+    /**
      * Send OPTIONS request
      *
      * @param string $service ICAP service
@@ -251,6 +262,17 @@ class IcapClient
     }
 
     /**
+     * Send RESPMOD request with streaming support.
+     */
+    public function respmodStream(string $service, array $body = [], array $headers = []): array
+    {
+        $request = $this->getRequestIterable(IcapProtocolConstants::METHOD_RESPMOD, $service, $body, $headers);
+        $response = $this->sendIterable($request);
+
+        return $this->parseResponse($response);
+    }
+
+    /**
      * Send REQMOD request
      *
      * @param string $service ICAP service
@@ -263,6 +285,17 @@ class IcapClient
     {
         $request = $this->getRequest(IcapProtocolConstants::METHOD_REQMOD, $service, $body, $headers);
         $response = $this->send($request);
+
+        return $this->parseResponse($response);
+    }
+
+    /**
+     * Send REQMOD request with streaming support.
+     */
+    public function reqmodStream(string $service, array $body = [], array $headers = []): array
+    {
+        $request = $this->getRequestIterable(IcapProtocolConstants::METHOD_REQMOD, $service, $body, $headers);
+        $response = $this->sendIterable($request);
 
         return $this->parseResponse($response);
     }
@@ -281,6 +314,47 @@ class IcapClient
 
         $this->socketClient->write($request);
 
+        $response = $this->readResponse();
+
+        if (!$this->persistentConnection) {
+            $this->disconnect();
+        }
+
+        return $response;
+    }
+
+    /**
+     * Send a request provided as iterable chunks.
+     *
+     * @param iterable $request Iterable yielding string chunks
+     * @return string Response string
+     * @throws IcapClientException
+     */
+    public function sendIterable(iterable $request): string
+    {
+        $this->connect();
+
+        foreach ($request as $chunk) {
+            if ($chunk === '') {
+                continue;
+            }
+            $this->socketClient->write($chunk);
+        }
+
+        $response = $this->readResponse();
+
+        if (!$this->persistentConnection) {
+            $this->disconnect();
+        }
+
+        return $response;
+    }
+
+    /**
+     * Read the response from the socket.
+     */
+    private function readResponse(): string
+    {
         $response = '';
         $startTime = microtime(true);
         while (true) {
@@ -305,9 +379,6 @@ class IcapClient
             }
         }
 
-        if (!$this->persistentConnection) {
-            $this->disconnect();
-        }
         return $response;
     }
 

--- a/src/IcapClient/IcapRequestFormatter.php
+++ b/src/IcapClient/IcapRequestFormatter.php
@@ -91,4 +91,106 @@ class IcapRequestFormatter
 
         return $result;
     }
+
+    /**
+     * Create a generator producing the request in chunks. This avoids
+     * buffering the entire body in memory. Body sections provided as
+     * {@see \Generator} or iterable will be streamed.
+     *
+     * @return \Generator<string>
+     */
+    public function formatIterable(IcapRequest $request): \Generator
+    {
+        $headers = $request->headers;
+
+        if (!array_key_exists(IcapProtocolConstants::HEADER_HOST, $headers)) {
+            $headers[IcapProtocolConstants::HEADER_HOST] = $request->host;
+        }
+        if (!array_key_exists(IcapProtocolConstants::HEADER_USER_AGENT, $headers)) {
+            $headers[IcapProtocolConstants::HEADER_USER_AGENT] = 'PHP-ICAP-CLIENT/0.5.0';
+        }
+        if (!array_key_exists(IcapProtocolConstants::HEADER_CONNECTION, $headers)) {
+            $headers[IcapProtocolConstants::HEADER_CONNECTION] = 'close';
+        }
+
+        $prefixData = '';
+        $encapsulated = [];
+        $streamSection = null;
+        $streamData = null;
+
+        foreach ($request->body as $type => $data) {
+            switch ($type) {
+                case IcapProtocolConstants::SECTION_REQ_HDR:
+                case IcapProtocolConstants::SECTION_RES_HDR:
+                    $encapsulated[$type] = strlen($prefixData);
+                    if (is_resource($data)) {
+                        $content = stream_get_contents($data);
+                        if ($content === false) {
+                            throw new Exception\IcapFileException('Unable to read body stream');
+                        }
+                    } else {
+                        $content = $data;
+                    }
+                    $prefixData .= $content;
+                    break;
+
+                case IcapProtocolConstants::SECTION_REQ_BODY:
+                case IcapProtocolConstants::SECTION_RES_BODY:
+                    $encapsulated[$type] = strlen($prefixData);
+                    $streamSection = $type;
+                    if (is_iterable($data)) {
+                        $streamData = $data;
+                    } elseif (is_resource($data)) {
+                        $streamData = (static function ($handle) {
+                            while (!feof($handle)) {
+                                $chunk = fread($handle, 8192);
+                                if ($chunk === false) {
+                                    break;
+                                }
+                                if ($chunk === '') {
+                                    continue;
+                                }
+                                yield $chunk;
+                            }
+                        })($data);
+                    } else {
+                        $streamData = [$data];
+                    }
+                    break;
+            }
+        }
+
+        if ($streamSection === null && count($encapsulated) > 0) {
+            $encapsulated[IcapProtocolConstants::SECTION_NULL_BODY] = strlen($prefixData);
+        }
+
+        if (count($encapsulated) > 0) {
+            $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] = '';
+            foreach ($encapsulated as $section => $offset) {
+                $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] .= $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] === '' ? '' : ', ';
+                $headers[IcapProtocolConstants::HEADER_ENCAPSULATED] .= "{$section}={$offset}";
+            }
+        }
+
+        $requestLine = "{$request->method} icap://{$request->host}/{$request->service} " .
+            IcapProtocolConstants::PROTOCOL_PREFIX . IcapProtocolConstants::PROTOCOL_VERSION . "\r\n";
+        $headerString = '';
+        foreach ($headers as $header => $value) {
+            $sanitizedValue = str_replace(["\r", "\n"], '', $value);
+            $headerString .= "{$header}: {$sanitizedValue}\r\n";
+        }
+
+        yield $requestLine . $headerString . "\r\n" . $prefixData;
+
+        if ($streamSection !== null && $streamData !== null) {
+            foreach ($streamData as $chunk) {
+                if ($chunk === '') {
+                    continue;
+                }
+                $len = dechex(strlen($chunk));
+                yield $len . "\r\n" . $chunk . "\r\n";
+            }
+            yield "0\r\n\r\n";
+        }
+    }
 }

--- a/tests/IcapRequestFormatterTest.php
+++ b/tests/IcapRequestFormatterTest.php
@@ -51,4 +51,68 @@ class IcapRequestFormatterTest extends TestCase
         $this->assertStringContainsString("X-Test: fooInjected: bar\r\n", $result);
         $this->assertStringNotContainsString("\nInjected:", $result);
     }
+
+    public function testFormatIterableMatchesFormat()
+    {
+        $request = new IcapRequest(
+            'RESPMOD',
+            'icap.test',
+            'example',
+            [],
+            [
+                'res-hdr' => "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n",
+                'res-body' => 'This is a test.'
+            ]
+        );
+
+        $formatter = new IcapRequestFormatter();
+        $expected = $formatter->format($request);
+        $result = '';
+        foreach ($formatter->formatIterable($request) as $chunk) {
+            $result .= $chunk;
+        }
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testStreamingBodyGenerator()
+    {
+        $generator = static function () {
+            yield 'This ';
+            yield 'is ';
+            yield 'a ';
+            yield 'test.';
+        };
+
+        $request = new IcapRequest(
+            'RESPMOD',
+            'icap.test',
+            'example',
+            [],
+            [
+                'res-hdr' => "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n",
+                'res-body' => $generator(),
+            ]
+        );
+
+        $formatter = new IcapRequestFormatter();
+
+        $expected = $formatter->format(new IcapRequest(
+            'RESPMOD',
+            'icap.test',
+            'example',
+            [],
+            [
+                'res-hdr' => "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n",
+                'res-body' => 'This is a test.'
+            ]
+        ));
+
+        $result = '';
+        foreach ($formatter->formatIterable($request) as $chunk) {
+            $result .= $chunk;
+        }
+
+        $this->assertSame($expected, $result);
+    }
 }


### PR DESCRIPTION
## Summary
- stream large request bodies via generators with `formatIterable`
- add streaming helpers in `IcapClient`
- test generator-based formatting

## Testing
- `phpunit` *(fails: command not found)*
