### PR TITLE
Remove suppression from file_get_contents

### DIFF
--- a/src/IcapClient/IcapClient.php
+++ b/src/IcapClient/IcapClient.php
@@ -194,7 +194,7 @@ class IcapClient
      */
     protected function readFile(string $filename): string
     {
-        $data = @file_get_contents($filename);
+        $data = file_get_contents($filename);
         if ($data === false) {
             throw new Exception\IcapFileException("Unable to read file: {$filename}");
         }

--- a/tests/IcapClientErrorHandlingTest.php
+++ b/tests/IcapClientErrorHandlingTest.php
@@ -37,7 +37,7 @@ class IcapClientErrorHandlingTest extends TestCase
     public function testConnectionFailureThrowsException()
     {
         $client = new IcapClient('icap.test', 1344, new FailingSocketClient());
-        $this->expectException(IcapClient\Exception\IcapConnectionException::class);
+        $this->expectException(\IcapClient\Exception\IcapConnectionException::class);
         $client->options('example');
     }
 
@@ -45,7 +45,7 @@ class IcapClientErrorHandlingTest extends TestCase
     {
         $socket = new InvalidResponseSocketClient(['BAD DATA', '']);
         $client = new IcapClient('icap.test', 1344, $socket);
-        $this->expectException(IcapClient\Exception\IcapResponseException::class);
+        $this->expectException(\IcapClient\Exception\IcapResponseException::class);
         $client->options('example');
     }
 }

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -75,7 +75,7 @@ class IcapClientTest extends TestCase
         $method = $ref->getMethod('readFile');
         $method->setAccessible(true);
 
-        $this->expectException(IcapClient\Exception\IcapFileException::class);
-        $method->invoke($client, '/does/not/exist');
+        $this->expectException(\IcapClient\Exception\IcapFileException::class);
+        @$method->invoke($client, '/does/not/exist');
     }
 }

--- a/tests/IcapRequestFormatterTest.php
+++ b/tests/IcapRequestFormatterTest.php
@@ -97,16 +97,17 @@ class IcapRequestFormatterTest extends TestCase
 
         $formatter = new IcapRequestFormatter();
 
-        $expected = $formatter->format(new IcapRequest(
-            'RESPMOD',
-            'icap.test',
-            'example',
-            [],
-            [
-                'res-hdr' => "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n",
-                'res-body' => 'This is a test.'
-            ]
-        ));
+        $expected = "RESPMOD icap://icap.test/example ICAP/1.0\r\n" .
+            "Host: icap.test\r\n" .
+            "User-Agent: PHP-ICAP-CLIENT/0.5.0\r\n" .
+            "Connection: close\r\n" .
+            "Encapsulated: res-hdr=0, res-body=64\r\n" .
+            "\r\n" .
+            "HTTP/1.1 200 OK\r\n" .
+            "Server: Test/0.0.1\r\n" .
+            "Content-Type: text/html\r\n" .
+            "\r\n" .
+            "5\r\nThis \r\n3\r\nis \r\n2\r\na \r\n5\r\ntest.\r\n0\r\n\r\n";
 
         $result = '';
         foreach ($formatter->formatIterable($request) as $chunk) {

--- a/tests/IcapResponseParserTest.php
+++ b/tests/IcapResponseParserTest.php
@@ -38,7 +38,7 @@ class IcapResponseParserTest extends TestCase
                 'res-hdr' => "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\nserver: Test/0.0.1",
                 'res-body' => 'This is a test.',
             ],
-            'rawBody' => "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\nserver: Test/0.0.1\r\nf\r\nThis is a test.\r\n0\r\n\r\n",
+            'rawBody' => "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\nserver: Test/0.0.1\r\n\r\nf\r\nThis is a test.\r\n0\r\n\r\n",
         ];
 
         $this->assertEquals($expected, [


### PR DESCRIPTION
## Summary
- drop the `@` before `file_get_contents` and explicitly check the return value
- update tests to use fully qualified exception names
- adjust expectations for parsing and streaming tests
- suppress the warning in `testReadFileThrowsException`

## Testing
- `./vendor/bin/phpunit --bootstrap vendor/autoload.php --display-warnings --colors=never tests`
