### PR TITLE
Add transport abstraction

### DIFF
--- a/src/IcapClient/IcapClient.php
+++ b/src/IcapClient/IcapClient.php
@@ -3,12 +3,11 @@ declare(strict_types=1);
 
 namespace IcapClient;
 
-use IcapClient\Socket\SocketClientInterface;
-use IcapClient\Socket\PhpSocketClient;
 use IcapClient\Exception\IcapClientException;
-use IcapClient\Exception\IcapConnectionException;
 use IcapClient\Exception\IcapResponseException;
 use IcapClient\Exception\IcapFileException;
+use IcapClient\Transport\TransportInterface;
+use IcapClient\Transport\IcapTransport;
 use IcapClient\IcapProtocolConstants;
 use IcapClient\DTO\IcapRequest;
 use IcapClient\DTO\IcapResponse;
@@ -24,11 +23,8 @@ class IcapClient
     /** @var string Address of ICAP server */
     private string $host;
 
-    /** @var int Port number */
-    private int $port;
-
-    /** @var SocketClientInterface Socket client implementation */
-    private SocketClientInterface $socketClient;
+    /** @var TransportInterface Transport implementation */
+    private TransportInterface $transport;
 
     /** @var IcapRequestFormatter */
     private IcapRequestFormatter $requestFormatter;
@@ -39,17 +35,6 @@ class IcapClient
     /** @var string User agent string */
     private string $userAgent = 'PHP-ICAP-CLIENT/0.5.0';
 
-    /** @var bool Keep the socket connection open between requests */
-    private bool $persistentConnection = false;
-
-    /** @var bool Connection state */
-    private bool $connected = false;
-
-    /** @var int Maximum number of bytes to read before aborting */
-    private int $maxResponseSize = 10485760; // 10 MiB default
-
-    /** @var float Maximum seconds to wait for a response */
-    private float $readTimeout = 5.0;
 
     /**
      * Constructor
@@ -60,52 +45,22 @@ class IcapClient
     public function __construct(
         string $host,
         int $port,
-        SocketClientInterface $socketClient = null,
+        TransportInterface $transport = null,
         IcapRequestFormatter $requestFormatter = null,
         IcapResponseParser $responseParser = null
     )
     {
         $this->host = $host;
-        $this->port = $port;
-        $this->socketClient = $socketClient ?? new PhpSocketClient();
+        $this->transport = $transport ?? new IcapTransport($host, $port, new \IcapClient\Socket\PhpSocketClient());
         $this->requestFormatter = $requestFormatter ?? new IcapRequestFormatter();
         $this->responseParser = $responseParser ?? new IcapResponseParser();
     }
-
-    /**
-     * Establish a socket connection to the configured ICAP server.
-     *
-     * The socket is closed and reset if the connection attempt fails and a
-     * {@see IcapConnectionException} is thrown.
-     *
-     * @return bool True on success
-     * @throws IcapConnectionException If the socket cannot be created or the
-     *     connection fails
-     */
-    private function connect(): bool
-    {
-        if ($this->connected) {
-            return true;
-        }
-
-        if (!$this->socketClient->connect($this->host, $this->port)) {
-            $errorMessage = socket_strerror($this->socketClient->getLastError());
-            throw new IcapConnectionException(
-                "Cannot connect to icap://{$this->host}:{$this->port} (Socket error: {$errorMessage})"
-            );
-        }
-
-        $this->connected = true;
-        return true;
-    }
-
     /**
      * Close connection to ICAP server
      */
     public function disconnect(): void
     {
-        $this->socketClient->disconnect();
-        $this->connected = false;
+        $this->transport->disconnect();
     }
 
     /**
@@ -115,7 +70,7 @@ class IcapClient
      */
     public function getLastSocketError(): int
     {
-        return $this->socketClient->getLastError();
+        return $this->transport->getLastSocketError();
     }
 
     /**
@@ -144,7 +99,7 @@ class IcapClient
      */
     public function setPersistentConnection(bool $persistent): void
     {
-        $this->persistentConnection = $persistent;
+        $this->transport->setPersistentConnection($persistent);
     }
 
     /**
@@ -152,7 +107,7 @@ class IcapClient
      */
     public function isPersistentConnection(): bool
     {
-        return $this->persistentConnection;
+        return $this->transport->isPersistentConnection();
     }
 
     /**
@@ -160,7 +115,7 @@ class IcapClient
      */
     public function setMaxResponseSize(int $maxSize): void
     {
-        $this->maxResponseSize = $maxSize;
+        $this->transport->setMaxResponseSize($maxSize);
     }
 
     /**
@@ -168,7 +123,7 @@ class IcapClient
      */
     public function getMaxResponseSize(): int
     {
-        return $this->maxResponseSize;
+        return $this->transport->getMaxResponseSize();
     }
 
     /**
@@ -176,7 +131,7 @@ class IcapClient
      */
     public function setReadTimeout(float $timeout): void
     {
-        $this->readTimeout = $timeout;
+        $this->transport->setReadTimeout($timeout);
     }
 
     /**
@@ -184,7 +139,7 @@ class IcapClient
      */
     public function getReadTimeout(): float
     {
-        return $this->readTimeout;
+        return $this->transport->getReadTimeout();
     }
 
     /**
@@ -309,18 +264,7 @@ class IcapClient
      */
     public function send(string $request): string
     {
-        // connect() now throws a specific connection exception with more detail
-        $this->connect();
-
-        $this->socketClient->write($request);
-
-        $response = $this->readResponse();
-
-        if (!$this->persistentConnection) {
-            $this->disconnect();
-        }
-
-        return $response;
+        return $this->transport->send($request);
     }
 
     /**
@@ -332,54 +276,7 @@ class IcapClient
      */
     public function sendIterable(iterable $request): string
     {
-        $this->connect();
-
-        foreach ($request as $chunk) {
-            if ($chunk === '') {
-                continue;
-            }
-            $this->socketClient->write($chunk);
-        }
-
-        $response = $this->readResponse();
-
-        if (!$this->persistentConnection) {
-            $this->disconnect();
-        }
-
-        return $response;
-    }
-
-    /**
-     * Read the response from the socket.
-     */
-    private function readResponse(): string
-    {
-        $response = '';
-        $startTime = microtime(true);
-        while (true) {
-            $buffer = $this->socketClient->read(2048);
-
-            if ($buffer === '') {
-                if ($this->socketClient->getLastError() !== 0) {
-                    $error = socket_strerror($this->socketClient->getLastError());
-                    throw new IcapClientException("Socket read error: {$error}");
-                }
-                break;
-            }
-
-            $response .= $buffer;
-
-            if (strlen($response) > $this->maxResponseSize) {
-                throw new IcapClientException('Maximum response size exceeded');
-            }
-
-            if ((microtime(true) - $startTime) > $this->readTimeout) {
-                throw new IcapClientException('Read timeout exceeded');
-            }
-        }
-
-        return $response;
+        return $this->transport->sendIterable($request);
     }
 
     /**

--- a/src/IcapClient/Transport/IcapTransport.php
+++ b/src/IcapClient/Transport/IcapTransport.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+namespace IcapClient\Transport;
+
+use IcapClient\Exception\IcapClientException;
+use IcapClient\Exception\IcapConnectionException;
+use IcapClient\Socket\PhpSocketClient;
+use IcapClient\Socket\SocketClientInterface;
+
+/**
+ * Default transport implementation using {@link SocketClientInterface}.
+ */
+class IcapTransport implements TransportInterface
+{
+    private string $host;
+    private int $port;
+    private SocketClientInterface $socketClient;
+
+    private bool $persistentConnection = false;
+    private bool $connected = false;
+    private int $maxResponseSize = 10485760; // 10 MiB
+    private float $readTimeout = 5.0;
+
+    public function __construct(string $host, int $port, SocketClientInterface $socketClient = null)
+    {
+        $this->host = $host;
+        $this->port = $port;
+        $this->socketClient = $socketClient ?? new PhpSocketClient();
+    }
+
+    public function setPersistentConnection(bool $persistent): void
+    {
+        $this->persistentConnection = $persistent;
+    }
+
+    public function isPersistentConnection(): bool
+    {
+        return $this->persistentConnection;
+    }
+
+    public function setMaxResponseSize(int $maxSize): void
+    {
+        $this->maxResponseSize = $maxSize;
+    }
+
+    public function getMaxResponseSize(): int
+    {
+        return $this->maxResponseSize;
+    }
+
+    public function setReadTimeout(float $timeout): void
+    {
+        $this->readTimeout = $timeout;
+        $this->socketClient->setReadTimeout($timeout);
+    }
+
+    public function getReadTimeout(): float
+    {
+        return $this->readTimeout;
+    }
+
+    public function getLastSocketError(): int
+    {
+        return $this->socketClient->getLastError();
+    }
+
+    public function disconnect(): void
+    {
+        $this->socketClient->disconnect();
+        $this->connected = false;
+    }
+
+    private function connect(): bool
+    {
+        if ($this->connected) {
+            return true;
+        }
+
+        if (!$this->socketClient->connect($this->host, $this->port)) {
+            $errorMessage = socket_strerror($this->socketClient->getLastError());
+            throw new IcapConnectionException(
+                "Cannot connect to icap://{$this->host}:{$this->port} (Socket error: {$errorMessage})"
+            );
+        }
+
+        $this->connected = true;
+        return true;
+    }
+
+    public function send(string $request): string
+    {
+        $this->connect();
+
+        $this->socketClient->write($request);
+
+        $response = $this->readResponse();
+
+        if (!$this->persistentConnection) {
+            $this->disconnect();
+        }
+
+        return $response;
+    }
+
+    public function sendIterable(iterable $request): string
+    {
+        $this->connect();
+
+        foreach ($request as $chunk) {
+            if ($chunk === '') {
+                continue;
+            }
+            $this->socketClient->write($chunk);
+        }
+
+        $response = $this->readResponse();
+
+        if (!$this->persistentConnection) {
+            $this->disconnect();
+        }
+
+        return $response;
+    }
+
+    private function readResponse(): string
+    {
+        $response = '';
+        $startTime = microtime(true);
+        while (true) {
+            $buffer = $this->socketClient->read(2048);
+
+            if ($buffer === '') {
+                if ($this->socketClient->getLastError() !== 0) {
+                    $error = socket_strerror($this->socketClient->getLastError());
+                    throw new IcapClientException("Socket read error: {$error}");
+                }
+                break;
+            }
+
+            $response .= $buffer;
+
+            if (strlen($response) > $this->maxResponseSize) {
+                throw new IcapClientException('Maximum response size exceeded');
+            }
+
+            if ((microtime(true) - $startTime) > $this->readTimeout) {
+                throw new IcapClientException('Read timeout exceeded');
+            }
+        }
+
+        return $response;
+    }
+}

--- a/src/IcapClient/Transport/TransportInterface.php
+++ b/src/IcapClient/Transport/TransportInterface.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace IcapClient\Transport;
+
+interface TransportInterface
+{
+    /**
+     * Send a complete request string and return the response.
+     */
+    public function send(string $request): string;
+
+    /**
+     * Send a request provided as iterable chunks and return the response.
+     */
+    public function sendIterable(iterable $request): string;
+
+    /**
+     * Close the underlying connection.
+     */
+    public function disconnect(): void;
+
+    /**
+     * Return last socket error code.
+     */
+    public function getLastSocketError(): int;
+
+    /** Enable or disable persistent connections. */
+    public function setPersistentConnection(bool $persistent): void;
+
+    /** Check if persistent connections are enabled. */
+    public function isPersistentConnection(): bool;
+
+    /** Set the maximum response size in bytes. */
+    public function setMaxResponseSize(int $maxSize): void;
+
+    /** Get the maximum response size in bytes. */
+    public function getMaxResponseSize(): int;
+
+    /** Set read timeout in seconds. */
+    public function setReadTimeout(float $timeout): void;
+
+    /** Get read timeout in seconds. */
+    public function getReadTimeout(): float;
+}

--- a/tests/IcapClientErrorHandlingTest.php
+++ b/tests/IcapClientErrorHandlingTest.php
@@ -2,6 +2,7 @@
 
 use IcapClient\IcapClient;
 use IcapClient\Socket\SocketClientInterface;
+use IcapClient\Transport\IcapTransport;
 use PHPUnit\Framework\TestCase;
 
 class FailingSocketClient implements SocketClientInterface
@@ -36,7 +37,8 @@ class IcapClientErrorHandlingTest extends TestCase
 {
     public function testConnectionFailureThrowsException()
     {
-        $client = new IcapClient('icap.test', 1344, new FailingSocketClient());
+        $transport = new IcapTransport('icap.test', 1344, new FailingSocketClient());
+        $client = new IcapClient('icap.test', 1344, $transport);
         $this->expectException(\IcapClient\Exception\IcapConnectionException::class);
         $client->options('example');
     }
@@ -44,7 +46,8 @@ class IcapClientErrorHandlingTest extends TestCase
     public function testInvalidResponseThrowsException()
     {
         $socket = new InvalidResponseSocketClient(['BAD DATA', '']);
-        $client = new IcapClient('icap.test', 1344, $socket);
+        $transport = new IcapTransport('icap.test', 1344, $socket);
+        $client = new IcapClient('icap.test', 1344, $transport);
         $this->expectException(\IcapClient\Exception\IcapResponseException::class);
         $client->options('example');
     }

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -2,13 +2,15 @@
 
 use IcapClient\IcapClient;
 use IcapClient\Socket\PhpSocketClient;
+use IcapClient\Transport\IcapTransport;
 use PHPUnit\Framework\TestCase;
 
 class IcapClientTest extends TestCase
 {
     public function testGetRequest()
     {
-        $client = new IcapClient('icap.test', 1344, new PhpSocketClient());
+        $transport = new IcapTransport('icap.test', 1344, new PhpSocketClient());
+        $client = new IcapClient('icap.test', 1344, $transport);
         $body = [
             'res-hdr' => "HTTP/1.1 200 OK\r\nServer: Test/0.0.1\r\nContent-Type: text/html\r\n\r\n",
             'res-body' => 'This is a test.'
@@ -40,7 +42,8 @@ class IcapClientTest extends TestCase
             "\r\n" .
             "f\r\nThis is a test.\r\n0\r\n\r\n";
 
-        $client = new IcapClient('icap.test', 1344, new PhpSocketClient());
+        $transport = new IcapTransport('icap.test', 1344, new PhpSocketClient());
+        $client = new IcapClient('icap.test', 1344, $transport);
         $ref = new ReflectionClass($client);
         $method = $ref->getMethod('parseResponse');
         $method->setAccessible(true);
@@ -70,7 +73,8 @@ class IcapClientTest extends TestCase
 
     public function testReadFileThrowsException()
     {
-        $client = new IcapClient('icap.test', 1344, new PhpSocketClient());
+        $transport = new IcapTransport('icap.test', 1344, new PhpSocketClient());
+        $client = new IcapClient('icap.test', 1344, $transport);
         $ref = new ReflectionClass($client);
         $method = $ref->getMethod('readFile');
         $method->setAccessible(true);


### PR DESCRIPTION
## Summary
- add IcapTransport and TransportInterface to separate network logic
- delegate network methods from `IcapClient` to the new transport
- update unit tests to use the new transport

## Testing
- `php -l src/IcapClient/Transport/IcapTransport.php`
- `php -l src/IcapClient/Transport/TransportInterface.php`
- `php -l src/IcapClient/IcapClient.php`
- `php -l tests/IcapClientTest.php`
- `php -l tests/IcapClientErrorHandlingTest.php`
- `php -d detect_unicode=0 vendor/bin/phpunit --bootstrap vendor/autoload.php tests` *(fails: Could not open input file)*
