### PR TITLE
Add basic PHPUnit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ $icap->respmod('example', [
 - **Socket\*** – pluggable socket layer so you can provide your own transport.
 - Data transfer objects can be found under the `DTO` namespace.
 
+## Running Tests
+
+Execute the following command to run the test suite:
+
+```
+vendor/bin/phpunit
+```
+
 ## License
 
 Released under the MIT license. See `LICENSE` for details.

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "require": {
         "php": ">=7.4"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
     "autoload": {
         "psr-4": {
             "IcapClient\\": "src/IcapClient/"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="ICAP Client Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- configure PHPUnit as a dev dependency
- add a minimal `phpunit.xml.dist`
- document how to run tests

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
