### PR TITLE
Add timeout and parse exceptions

### DIFF
--- a/src/IcapClient/Exception/IcapParseException.php
+++ b/src/IcapClient/Exception/IcapParseException.php
@@ -1,0 +1,9 @@
+<?php
+namespace IcapClient\Exception;
+
+/**
+ * Thrown when parsing the ICAP response fails.
+ */
+class IcapParseException extends IcapResponseException
+{
+}

--- a/src/IcapClient/Exception/IcapTimeoutException.php
+++ b/src/IcapClient/Exception/IcapTimeoutException.php
@@ -1,0 +1,9 @@
+<?php
+namespace IcapClient\Exception;
+
+/**
+ * Thrown when the read operation exceeds the configured timeout.
+ */
+class IcapTimeoutException extends IcapClientException
+{
+}

--- a/src/IcapClient/IcapResponseParser.php
+++ b/src/IcapClient/IcapResponseParser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace IcapClient;
 
 use IcapClient\DTO\IcapResponse;
-use IcapClient\Exception\IcapResponseException;
+use IcapClient\Exception\IcapParseException;
 
 /**
  * Parse raw ICAP responses into a structured representation.
@@ -14,7 +14,7 @@ class IcapResponseParser
     /**
      * Parse the given response string.
      *
-     * @throws IcapResponseException If the response does not contain valid ICAP data
+     * @throws IcapParseException If the response does not contain valid ICAP data
      */
     public function parse(string $response): IcapResponse
     {
@@ -23,7 +23,7 @@ class IcapResponseParser
         foreach (preg_split('/\r?\n/', $response) as $line) {
             if ([] === $result->protocol) {
                 if (0 !== strpos($line, IcapProtocolConstants::PROTOCOL_PREFIX)) {
-                    throw new IcapResponseException('Unknown ICAP response');
+                    throw new IcapParseException('Unknown ICAP response');
                 }
                 $parts = preg_split('/\ +/', $line, 3);
                 $result->protocol = [

--- a/src/IcapClient/Transport/IcapTransport.php
+++ b/src/IcapClient/Transport/IcapTransport.php
@@ -5,6 +5,7 @@ namespace IcapClient\Transport;
 
 use IcapClient\Exception\IcapClientException;
 use IcapClient\Exception\IcapConnectionException;
+use IcapClient\Exception\IcapTimeoutException;
 use IcapClient\Socket\PhpSocketClient;
 use IcapClient\Socket\SocketClientInterface;
 
@@ -145,7 +146,7 @@ class IcapTransport implements TransportInterface
             }
 
             if ((microtime(true) - $startTime) > $this->readTimeout) {
-                throw new IcapClientException('Read timeout exceeded');
+                throw new IcapTimeoutException('Read timeout exceeded');
             }
         }
 

--- a/tests/IcapClientErrorHandlingTest.php
+++ b/tests/IcapClientErrorHandlingTest.php
@@ -33,6 +33,23 @@ class InvalidResponseSocketClient implements SocketClientInterface
     public function getWriteTimeout(): float { return 0.0; }
 }
 
+class TimeoutSocketClient implements SocketClientInterface
+{
+    private float $readTimeout = 0.0;
+    public function connect(string $host, int $port): bool { return true; }
+    public function write(string $data): int { return strlen($data); }
+    public function read(int $length): string {
+        usleep((int)(($this->readTimeout + 0.05) * 1_000_000));
+        return 'a';
+    }
+    public function disconnect(): void {}
+    public function getLastError(): int { return 0; }
+    public function setReadTimeout(float $timeout): void { $this->readTimeout = $timeout; }
+    public function getReadTimeout(): float { return $this->readTimeout; }
+    public function setWriteTimeout(float $timeout): void {}
+    public function getWriteTimeout(): float { return 0.0; }
+}
+
 class IcapClientErrorHandlingTest extends TestCase
 {
     public function testConnectionFailureThrowsException()
@@ -48,7 +65,17 @@ class IcapClientErrorHandlingTest extends TestCase
         $socket = new InvalidResponseSocketClient(['BAD DATA', '']);
         $transport = new IcapTransport('icap.test', 1344, $socket);
         $client = new IcapClient('icap.test', 1344, $transport);
-        $this->expectException(\IcapClient\Exception\IcapResponseException::class);
+        $this->expectException(\IcapClient\Exception\IcapParseException::class);
+        $client->options('example');
+    }
+
+    public function testReadTimeoutThrowsException()
+    {
+        $socket = new TimeoutSocketClient();
+        $transport = new IcapTransport('icap.test', 1344, $socket);
+        $transport->setReadTimeout(0.1);
+        $client = new IcapClient('icap.test', 1344, $transport);
+        $this->expectException(\IcapClient\Exception\IcapTimeoutException::class);
         $client->options('example');
     }
 }

--- a/tests/IcapResponseParserTest.php
+++ b/tests/IcapResponseParserTest.php
@@ -48,4 +48,11 @@ class IcapResponseParserTest extends TestCase
             'rawBody' => $result->rawBody,
         ]);
     }
+
+    public function testInvalidResponseThrowsException()
+    {
+        $parser = new IcapResponseParser();
+        $this->expectException(\IcapClient\Exception\IcapParseException::class);
+        $parser->parse('BAD');
+    }
 }


### PR DESCRIPTION
## Summary
- add `IcapTimeoutException` and `IcapParseException`
- use `IcapTimeoutException` in `IcapTransport` for read timeouts
- raise `IcapParseException` when parsing fails
- extend tests for new exceptions

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml.dist`
