### PR TITLE
Add waitForData support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,17 @@ $icap->respmod('example', [
 - **IcapClient** – high-level API that uses the formatter, parser and socket implementation.
 - **IcapRequestFormatter** – turns request objects into raw ICAP strings.
 - **IcapResponseParser** – parses server responses into structured objects.
-- **Socket\*** – pluggable socket layer so you can provide your own transport.
+- **Socket\*** – pluggable socket layer so you can provide your own transport. The
+  socket interface exposes a `waitForData()` method used to efficiently wait for
+  incoming bytes.
 - Data transfer objects can be found under the `DTO` namespace.
+
+### Timeout Handling
+
+The transport resets the read timer every time data is received. Large responses
+therefore do not trigger a timeout as long as more bytes keep arriving. If no
+data becomes available within the configured timeout, an
+`IcapTimeoutException` is thrown.
 
 ## Running Tests
 

--- a/src/IcapClient/Socket/PhpSocketClient.php
+++ b/src/IcapClient/Socket/PhpSocketClient.php
@@ -144,4 +144,21 @@ class PhpSocketClient implements SocketClientInterface
     {
         return $this->writeTimeout;
     }
+
+    public function waitForData(float $timeout): bool
+    {
+        if (!$this->socket instanceof Socket) {
+            return false;
+        }
+
+        $read = [$this->socket];
+        $sec = (int) $timeout;
+        $usec = (int) (($timeout - $sec) * 1_000_000);
+        $result = @socket_select($read, $write = null, $except = null, $sec, $usec);
+        if ($result === false) {
+            return false;
+        }
+
+        return $result > 0;
+    }
 }

--- a/src/IcapClient/Socket/SocketClientInterface.php
+++ b/src/IcapClient/Socket/SocketClientInterface.php
@@ -52,4 +52,12 @@ interface SocketClientInterface
      * Get write timeout in seconds.
      */
     public function getWriteTimeout(): float;
+
+    /**
+     * Block until data is available to read or the timeout elapses.
+     *
+     * @param float $timeout Timeout in seconds
+     * @return bool True if data is ready, false on timeout or error
+     */
+    public function waitForData(float $timeout): bool;
 }

--- a/src/IcapClient/Transport/IcapTransport.php
+++ b/src/IcapClient/Transport/IcapTransport.php
@@ -127,8 +127,11 @@ class IcapTransport implements TransportInterface
     private function readResponse(): string
     {
         $response = '';
-        $startTime = microtime(true);
         while (true) {
+            if (!$this->socketClient->waitForData($this->readTimeout)) {
+                throw new IcapTimeoutException('Read timeout exceeded');
+            }
+
             $buffer = $this->socketClient->read(2048);
 
             if ($buffer === '') {
@@ -143,10 +146,6 @@ class IcapTransport implements TransportInterface
 
             if (strlen($response) > $this->maxResponseSize) {
                 throw new IcapClientException('Maximum response size exceeded');
-            }
-
-            if ((microtime(true) - $startTime) > $this->readTimeout) {
-                throw new IcapTimeoutException('Read timeout exceeded');
             }
         }
 

--- a/tests/IcapClientErrorHandlingTest.php
+++ b/tests/IcapClientErrorHandlingTest.php
@@ -16,6 +16,7 @@ class FailingSocketClient implements SocketClientInterface
     public function getReadTimeout(): float { return 0.0; }
     public function setWriteTimeout(float $timeout): void {}
     public function getWriteTimeout(): float { return 0.0; }
+    public function waitForData(float $timeout): bool { return false; }
 }
 
 class InvalidResponseSocketClient implements SocketClientInterface
@@ -31,6 +32,7 @@ class InvalidResponseSocketClient implements SocketClientInterface
     public function getReadTimeout(): float { return 0.0; }
     public function setWriteTimeout(float $timeout): void {}
     public function getWriteTimeout(): float { return 0.0; }
+    public function waitForData(float $timeout): bool { return true; }
 }
 
 class TimeoutSocketClient implements SocketClientInterface
@@ -38,16 +40,17 @@ class TimeoutSocketClient implements SocketClientInterface
     private float $readTimeout = 0.0;
     public function connect(string $host, int $port): bool { return true; }
     public function write(string $data): int { return strlen($data); }
-    public function read(int $length): string {
-        usleep((int)(($this->readTimeout + 0.05) * 1_000_000));
-        return 'a';
-    }
+    public function read(int $length): string { return 'a'; }
     public function disconnect(): void {}
     public function getLastError(): int { return 0; }
     public function setReadTimeout(float $timeout): void { $this->readTimeout = $timeout; }
     public function getReadTimeout(): float { return $this->readTimeout; }
     public function setWriteTimeout(float $timeout): void {}
     public function getWriteTimeout(): float { return 0.0; }
+    public function waitForData(float $timeout): bool {
+        usleep((int)(($timeout + 0.05) * 1_000_000));
+        return false;
+    }
 }
 
 class IcapClientErrorHandlingTest extends TestCase

--- a/tests/IcapTransportTest.php
+++ b/tests/IcapTransportTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use IcapClient\Transport\IcapTransport;
+use IcapClient\Socket\SocketClientInterface;
+use IcapClient\Exception\IcapTimeoutException;
+use PHPUnit\Framework\TestCase;
+
+class StreamingSocketClient implements SocketClientInterface
+{
+    private array $chunks;
+    private float $delay;
+    private int $index = 0;
+
+    public function __construct(array $chunks, float $delay)
+    {
+        $this->chunks = $chunks;
+        $this->delay = $delay;
+    }
+
+    public function connect(string $host, int $port): bool { return true; }
+    public function write(string $data): int { return strlen($data); }
+    public function read(int $length): string { return $this->chunks[$this->index++] ?? ''; }
+    public function disconnect(): void {}
+    public function getLastError(): int { return 0; }
+    public function setReadTimeout(float $timeout): void {}
+    public function getReadTimeout(): float { return 0.0; }
+    public function setWriteTimeout(float $timeout): void {}
+    public function getWriteTimeout(): float { return 0.0; }
+    public function waitForData(float $timeout): bool
+    {
+        if ($this->index >= count($this->chunks)) {
+            usleep((int)($timeout * 1_000_000));
+            return false;
+        }
+        usleep((int)($this->delay * 1_000_000));
+        return true;
+    }
+}
+
+class IcapTransportTest extends TestCase
+{
+    public function testLargeResponseArrivingInChunksDoesNotTimeout()
+    {
+        $chunks = [];
+        for ($i = 0; $i < 20; $i++) {
+            $chunks[] = str_repeat('a', 256);
+        }
+        $socket = new StreamingSocketClient($chunks, 0.05);
+        $transport = new IcapTransport('icap.test', 1344, $socket);
+        $transport->setReadTimeout(0.2);
+
+        $response = $transport->send('REQ');
+
+        $this->assertSame(implode('', $chunks), $response);
+    }
+
+    public function testWaitForDataTimeoutThrowsException()
+    {
+        $socket = new StreamingSocketClient([], 0.0);
+        $transport = new IcapTransport('icap.test', 1344, $socket);
+        $transport->setReadTimeout(0.1);
+
+        $this->expectException(IcapTimeoutException::class);
+        $transport->send('REQ');
+    }
+}

--- a/tests/PhpSocketClientTest.php
+++ b/tests/PhpSocketClientTest.php
@@ -47,4 +47,31 @@ class PhpSocketClientTest extends TestCase
         $client->setWriteTimeout(4.0);
         $this->assertSame(4.0, $client->getWriteTimeout());
     }
+
+    public function testWaitForData()
+    {
+        if (!function_exists('socket_create')) {
+            $this->markTestSkipped('Sockets extension not available');
+        }
+
+        $server = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        socket_bind($server, '127.0.0.1', 0);
+        socket_getsockname($server, $address, $port);
+        socket_listen($server, 1);
+
+        $client = new PhpSocketClient();
+        $this->assertTrue($client->connect($address, $port));
+
+        $peer = socket_accept($server);
+
+        $this->assertFalse($client->waitForData(0.1));
+
+        socket_write($peer, 'abc');
+        $this->assertTrue($client->waitForData(0.1));
+        $this->assertSame('abc', $client->read(3));
+
+        $client->disconnect();
+        socket_close($peer);
+        socket_close($server);
+    }
 }


### PR DESCRIPTION
## Summary
- extend `SocketClientInterface` with `waitForData()`
- implement waiting logic in `PhpSocketClient`
- rework `IcapTransport::readResponse()` to use the new method
- cover timeouts and streaming data in unit tests
- document timeout behaviour in README

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter` *(fails: phpunit requires dom and xml extensions)*
- `vendor/bin/phpunit -q` *(fails: missing dom, xml, xmlwriter extensions)*
