### PR TITLE
Add configurable read buffer size to transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ therefore do not trigger a timeout as long as more bytes keep arriving. If no
 data becomes available within the configured timeout, an
 `IcapTimeoutException` is thrown.
 
+### Read Buffer Size
+
+The transport reads data in chunks controlled by `setReadBufferSize()`. The
+default buffer size is 8192 bytes. Reduce this value when working with
+non‑blocking socket clients to limit how much data is read at a time.
+
+### Non‑blocking Sockets
+
+Custom implementations of `SocketClientInterface` may return immediately when no
+data is available (for example using `socket_set_nonblock()` or `stream_select`).
+The provided `PhpSocketClient` remains blocking by default but can be swapped
+out for a non‑blocking variant.
+
 ## Running Tests
 
 Execute the following command to run the test suite:

--- a/src/IcapClient/IcapClient.php
+++ b/src/IcapClient/IcapClient.php
@@ -143,6 +143,22 @@ class IcapClient
     }
 
     /**
+     * Set the read buffer size in bytes.
+     */
+    public function setReadBufferSize(int $bufferSize): void
+    {
+        $this->transport->setReadBufferSize($bufferSize);
+    }
+
+    /**
+     * Get the read buffer size in bytes.
+     */
+    public function getReadBufferSize(): int
+    {
+        return $this->transport->getReadBufferSize();
+    }
+
+    /**
      * Read the contents of a file and throw an exception on failure.
      *
      * @throws IcapFileException

--- a/src/IcapClient/Socket/PhpSocketClient.php
+++ b/src/IcapClient/Socket/PhpSocketClient.php
@@ -152,9 +152,11 @@ class PhpSocketClient implements SocketClientInterface
         }
 
         $read = [$this->socket];
+        $write = null;
+        $except = null;
         $sec = (int) $timeout;
         $usec = (int) (($timeout - $sec) * 1_000_000);
-        $result = @socket_select($read, $write = null, $except = null, $sec, $usec);
+        $result = @socket_select($read, $write, $except, $sec, $usec);
         if ($result === false) {
             return false;
         }

--- a/src/IcapClient/Transport/IcapTransport.php
+++ b/src/IcapClient/Transport/IcapTransport.php
@@ -22,6 +22,8 @@ class IcapTransport implements TransportInterface
     private bool $connected = false;
     private int $maxResponseSize = 10485760; // 10 MiB
     private float $readTimeout = 5.0;
+    /** @var int Size of read buffer in bytes */
+    private int $readBufferSize = 8192;
 
     public function __construct(string $host, int $port, SocketClientInterface $socketClient = null)
     {
@@ -59,6 +61,16 @@ class IcapTransport implements TransportInterface
     public function getReadTimeout(): float
     {
         return $this->readTimeout;
+    }
+
+    public function setReadBufferSize(int $bufferSize): void
+    {
+        $this->readBufferSize = $bufferSize;
+    }
+
+    public function getReadBufferSize(): int
+    {
+        return $this->readBufferSize;
     }
 
     public function getLastSocketError(): int
@@ -132,7 +144,7 @@ class IcapTransport implements TransportInterface
                 throw new IcapTimeoutException('Read timeout exceeded');
             }
 
-            $buffer = $this->socketClient->read(2048);
+            $buffer = $this->socketClient->read($this->readBufferSize);
 
             if ($buffer === '') {
                 if ($this->socketClient->getLastError() !== 0) {

--- a/src/IcapClient/Transport/TransportInterface.php
+++ b/src/IcapClient/Transport/TransportInterface.php
@@ -42,4 +42,10 @@ interface TransportInterface
 
     /** Get read timeout in seconds. */
     public function getReadTimeout(): float;
+
+    /** Set read buffer size in bytes. */
+    public function setReadBufferSize(int $bufferSize): void;
+
+    /** Get read buffer size in bytes. */
+    public function getReadBufferSize(): int;
 }

--- a/tests/IcapTransportTest.php
+++ b/tests/IcapTransportTest.php
@@ -10,6 +10,7 @@ class StreamingSocketClient implements SocketClientInterface
     private array $chunks;
     private float $delay;
     private int $index = 0;
+    private int $offset = 0;
 
     public function __construct(array $chunks, float $delay)
     {
@@ -19,19 +20,42 @@ class StreamingSocketClient implements SocketClientInterface
 
     public function connect(string $host, int $port): bool { return true; }
     public function write(string $data): int { return strlen($data); }
-    public function read(int $length): string { return $this->chunks[$this->index++] ?? ''; }
+    public function read(int $length): string
+    {
+        if (!isset($this->chunks[$this->index])) {
+            return '';
+        }
+
+        $chunk = $this->chunks[$this->index];
+        $data = substr($chunk, $this->offset, $length);
+        $this->offset += strlen($data);
+        if ($this->offset >= strlen($chunk)) {
+            $this->index++;
+            $this->offset = 0;
+        }
+
+        return $data;
+    }
     public function disconnect(): void {}
     public function getLastError(): int { return 0; }
     public function setReadTimeout(float $timeout): void {}
     public function getReadTimeout(): float { return 0.0; }
     public function setWriteTimeout(float $timeout): void {}
     public function getWriteTimeout(): float { return 0.0; }
+    private bool $eofSignalled = false;
+
     public function waitForData(float $timeout): bool
     {
         if ($this->index >= count($this->chunks)) {
-            usleep((int)($timeout * 1_000_000));
-            return false;
+            if ($this->index === 0 || $this->eofSignalled) {
+                usleep((int)($timeout * 1_000_000));
+                return false;
+            }
+
+            $this->eofSignalled = true;
+            return true;
         }
+
         usleep((int)($this->delay * 1_000_000));
         return true;
     }
@@ -48,6 +72,7 @@ class IcapTransportTest extends TestCase
         $socket = new StreamingSocketClient($chunks, 0.05);
         $transport = new IcapTransport('icap.test', 1344, $socket);
         $transport->setReadTimeout(0.2);
+        $transport->setReadBufferSize(128);
 
         $response = $transport->send('REQ');
 
@@ -62,5 +87,18 @@ class IcapTransportTest extends TestCase
 
         $this->expectException(IcapTimeoutException::class);
         $transport->send('REQ');
+    }
+
+    public function testLargeChunkWithSmallBufferIsReadCompletely()
+    {
+        $chunk = str_repeat('b', 300);
+        $socket = new StreamingSocketClient([$chunk], 0.0);
+        $transport = new IcapTransport('icap.test', 1344, $socket);
+        $transport->setReadTimeout(0.2);
+        $transport->setReadBufferSize(128);
+
+        $response = $transport->send('REQ');
+
+        $this->assertSame($chunk, $response);
     }
 }


### PR DESCRIPTION
## Summary
- allow setting read buffer size on IcapTransport
- expose read buffer size via IcapClient
- fix socket select call for PHP 8 by using variables
- document read buffer and non-blocking socket usage
- extend transport tests for configurable buffer

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit`
