### PR TITLE
Add strict types to ICAP constants and exceptions

### DIFF
--- a/src/Exception/IcapClientException.php
+++ b/src/Exception/IcapClientException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Ndrstmr\Icap\Exception;
 
 /**

--- a/src/Exception/IcapConnectionException.php
+++ b/src/Exception/IcapConnectionException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Ndrstmr\Icap\Exception;
 
 /**

--- a/src/Exception/IcapParseException.php
+++ b/src/Exception/IcapParseException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Ndrstmr\Icap\Exception;
 
 /**

--- a/src/Exception/IcapResponseException.php
+++ b/src/Exception/IcapResponseException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Ndrstmr\Icap\Exception;
 
 /**

--- a/src/Exception/IcapTimeoutException.php
+++ b/src/Exception/IcapTimeoutException.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Ndrstmr\Icap\Exception;
 
 /**

--- a/src/IcapProtocolConstants.php
+++ b/src/IcapProtocolConstants.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Ndrstmr\Icap;
 
 /**


### PR DESCRIPTION
## Summary
- enable `strict_types` in `IcapProtocolConstants`
- enable `strict_types` in ICAP exception classes

## Testing
- `composer test` *(fails: Class "IcapClient\Exception\..." does not exist)*
