### PR TITLE
Fix socket client namespace reference

### DIFF
--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -51,7 +51,7 @@ class IcapClient
     )
     {
         $this->host = $host;
-        $this->transport = $transport ?? new IcapTransport($host, $port, new \IcapClient\Socket\PhpSocketClient());
+        $this->transport = $transport ?? new IcapTransport($host, $port, new \Ndrstmr\Icap\Socket\PhpSocketClient());
         $this->requestFormatter = $requestFormatter ?? new IcapRequestFormatter();
         $this->responseParser = $responseParser ?? new IcapResponseParser();
     }


### PR DESCRIPTION
## Summary
- fix socket client namespace in IcapClient constructor
- ensure file ends with a newline

## Testing
- `composer install --no-interaction`
- `composer test` *(fails: Class "IcapClient\Exception\IcapParseException" does not exist)*
