### PR TITLE
Update PHP requirements and PHPUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The library offers a simple way to interact with Internet Content Adaptation Pro
 
 ## Requirements
 
-- PHP **7.4** or newer
+ - PHP **8.2** or newer
 - Composer for installing dependencies
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         }
     ],
     "require": {
-        "php": ">=7.4"
+        "php": ">=8.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- require PHP 8.2 or newer
- use PHPUnit ^10 in composer.json
- document the updated PHP version in the README

## Testing
- `vendor/bin/phpunit` *(fails: Class "IcapClient\Exception\..." does not exist)*
