### PR TITLE
Fix IcapFileException references

### DIFF
--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -167,7 +167,7 @@ class IcapClient
     {
         $data = file_get_contents($filename);
         if ($data === false) {
-            throw new Exception\IcapFileException("Unable to read file: {$filename}");
+            throw new IcapFileException("Unable to read file: {$filename}");
         }
 
         return $data;

--- a/src/IcapRequestFormatter.php
+++ b/src/IcapRequestFormatter.php
@@ -39,7 +39,7 @@ class IcapRequestFormatter
                     if (is_resource($data)) {
                         $content = stream_get_contents($data);
                         if ($content === false) {
-                            throw new Exception\IcapFileException('Unable to read body stream');
+                            throw new IcapFileException('Unable to read body stream');
                         }
                     } else {
                         $content = $data;
@@ -51,7 +51,7 @@ class IcapRequestFormatter
                     if (is_resource($data)) {
                         $content = stream_get_contents($data);
                         if ($content === false) {
-                            throw new Exception\IcapFileException('Unable to read body stream');
+                            throw new IcapFileException('Unable to read body stream');
                         }
                     } else {
                         $content = $data;
@@ -126,7 +126,7 @@ class IcapRequestFormatter
                     if (is_resource($data)) {
                         $content = stream_get_contents($data);
                         if ($content === false) {
-                            throw new Exception\IcapFileException('Unable to read body stream');
+                            throw new IcapFileException('Unable to read body stream');
                         }
                     } else {
                         $content = $data;


### PR DESCRIPTION
## Summary
- throw IcapFileException directly without namespace prefix

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Class "IcapClient\Exception\IcapConnectionException" does not exist)*
