### PR TITLE
Use enums for ICAP methods and sections

### DIFF
--- a/src/IcapBodySection.php
+++ b/src/IcapBodySection.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+/**
+ * Enumeration of supported encapsulated body section identifiers.
+ */
+enum IcapBodySection: string
+{
+    case REQ_HDR  = 'req-hdr';
+    case RES_HDR  = 'res-hdr';
+    case REQ_BODY = 'req-body';
+    case RES_BODY = 'res-body';
+    case NULL_BODY = 'null-body';
+}

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -209,7 +209,7 @@ class IcapClient
      */
     public function options(string $service): array
     {
-        $request = $this->getRequest(IcapProtocolConstants::METHOD_OPTIONS, $service);
+        $request = $this->getRequest(IcapMethod::OPTIONS->value, $service);
         $response = $this->send($request);
 
         return $this->parseResponse($response);
@@ -226,7 +226,7 @@ class IcapClient
      */
     public function respmod(string $service, array $body = [], array $headers = []): array
     {
-        $request = $this->getRequest(IcapProtocolConstants::METHOD_RESPMOD, $service, $body, $headers);
+        $request = $this->getRequest(IcapMethod::RESPMOD->value, $service, $body, $headers);
         $response = $this->send($request);
 
         return $this->parseResponse($response);
@@ -237,7 +237,7 @@ class IcapClient
      */
     public function respmodStream(string $service, array $body = [], array $headers = []): array
     {
-        $request = $this->getRequestIterable(IcapProtocolConstants::METHOD_RESPMOD, $service, $body, $headers);
+        $request = $this->getRequestIterable(IcapMethod::RESPMOD->value, $service, $body, $headers);
         $response = $this->sendIterable($request);
 
         return $this->parseResponse($response);
@@ -254,7 +254,7 @@ class IcapClient
      */
     public function reqmod(string $service, array $body = [], array $headers = []): array
     {
-        $request = $this->getRequest(IcapProtocolConstants::METHOD_REQMOD, $service, $body, $headers);
+        $request = $this->getRequest(IcapMethod::REQMOD->value, $service, $body, $headers);
         $response = $this->send($request);
 
         return $this->parseResponse($response);
@@ -265,7 +265,7 @@ class IcapClient
      */
     public function reqmodStream(string $service, array $body = [], array $headers = []): array
     {
-        $request = $this->getRequestIterable(IcapProtocolConstants::METHOD_REQMOD, $service, $body, $headers);
+        $request = $this->getRequestIterable(IcapMethod::REQMOD->value, $service, $body, $headers);
         $response = $this->sendIterable($request);
 
         return $this->parseResponse($response);

--- a/src/IcapMethod.php
+++ b/src/IcapMethod.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+/**
+ * Enumeration of supported ICAP methods.
+ */
+enum IcapMethod: string
+{
+    case OPTIONS = 'OPTIONS';
+    case RESPMOD = 'RESPMOD';
+    case REQMOD = 'REQMOD';
+}

--- a/src/IcapProtocolConstants.php
+++ b/src/IcapProtocolConstants.php
@@ -11,18 +11,8 @@ final class IcapProtocolConstants
     public const PROTOCOL_PREFIX = 'ICAP/';
     public const PROTOCOL_VERSION = '1.0';
 
-    public const METHOD_OPTIONS = 'OPTIONS';
-    public const METHOD_RESPMOD = 'RESPMOD';
-    public const METHOD_REQMOD = 'REQMOD';
-
     public const HEADER_HOST = 'Host';
     public const HEADER_USER_AGENT = 'User-Agent';
     public const HEADER_CONNECTION = 'Connection';
     public const HEADER_ENCAPSULATED = 'Encapsulated';
-
-    public const SECTION_REQ_HDR  = 'req-hdr';
-    public const SECTION_RES_HDR  = 'res-hdr';
-    public const SECTION_REQ_BODY = 'req-body';
-    public const SECTION_RES_BODY = 'res-body';
-    public const SECTION_NULL_BODY = 'null-body';
 }

--- a/src/IcapRequestFormatter.php
+++ b/src/IcapRequestFormatter.php
@@ -33,8 +33,8 @@ class IcapRequestFormatter
         $encapsulated = [];
         foreach ($request->body as $type => $data) {
             switch ($type) {
-                case IcapProtocolConstants::SECTION_REQ_HDR:
-                case IcapProtocolConstants::SECTION_RES_HDR:
+                case IcapBodySection::REQ_HDR->value:
+                case IcapBodySection::RES_HDR->value:
                     $encapsulated[$type] = strlen($bodyData);
                     if (is_resource($data)) {
                         $content = stream_get_contents($data);
@@ -46,8 +46,8 @@ class IcapRequestFormatter
                     }
                     $bodyData .= $content;
                     break;
-                case IcapProtocolConstants::SECTION_REQ_BODY:
-                case IcapProtocolConstants::SECTION_RES_BODY:
+                case IcapBodySection::REQ_BODY->value:
+                case IcapBodySection::RES_BODY->value:
                     if (is_resource($data)) {
                         $content = stream_get_contents($data);
                         if ($content === false) {
@@ -68,7 +68,7 @@ class IcapRequestFormatter
         if ($hasBody) {
             $bodyData .= "0\r\n\r\n";
         } elseif (count($encapsulated) > 0) {
-            $encapsulated[IcapProtocolConstants::SECTION_NULL_BODY] = strlen($bodyData);
+            $encapsulated[IcapBodySection::NULL_BODY->value] = strlen($bodyData);
         }
 
         if (count($encapsulated) > 0) {
@@ -120,8 +120,8 @@ class IcapRequestFormatter
 
         foreach ($request->body as $type => $data) {
             switch ($type) {
-                case IcapProtocolConstants::SECTION_REQ_HDR:
-                case IcapProtocolConstants::SECTION_RES_HDR:
+                case IcapBodySection::REQ_HDR->value:
+                case IcapBodySection::RES_HDR->value:
                     $encapsulated[$type] = strlen($prefixData);
                     if (is_resource($data)) {
                         $content = stream_get_contents($data);
@@ -134,8 +134,8 @@ class IcapRequestFormatter
                     $prefixData .= $content;
                     break;
 
-                case IcapProtocolConstants::SECTION_REQ_BODY:
-                case IcapProtocolConstants::SECTION_RES_BODY:
+                case IcapBodySection::REQ_BODY->value:
+                case IcapBodySection::RES_BODY->value:
                     $encapsulated[$type] = strlen($prefixData);
                     $streamSection = $type;
                     if (is_iterable($data)) {
@@ -161,7 +161,7 @@ class IcapRequestFormatter
         }
 
         if ($streamSection === null && count($encapsulated) > 0) {
-            $encapsulated[IcapProtocolConstants::SECTION_NULL_BODY] = strlen($prefixData);
+            $encapsulated[IcapBodySection::NULL_BODY->value] = strlen($prefixData);
         }
 
         if (count($encapsulated) > 0) {

--- a/src/IcapResponseParser.php
+++ b/src/IcapResponseParser.php
@@ -65,12 +65,12 @@ class IcapResponseParser
                 foreach ($encapsulated as $section => $offset) {
                     $data = substr($body[1], (int)$offset);
                     switch ($section) {
-                        case IcapProtocolConstants::SECTION_REQ_HDR:
-                        case IcapProtocolConstants::SECTION_RES_HDR:
+                        case IcapBodySection::REQ_HDR->value:
+                        case IcapBodySection::RES_HDR->value:
                             $bodySections[$section] = preg_split('/\r?\n\r?\n/', $data, 2)[0];
                             break;
-                        case IcapProtocolConstants::SECTION_REQ_BODY:
-                        case IcapProtocolConstants::SECTION_RES_BODY:
+                        case IcapBodySection::REQ_BODY->value:
+                        case IcapBodySection::RES_BODY->value:
                             $parts = preg_split('/\r?\n/', $data, 2);
                             if (count($parts) === 2) {
                                 $bodySections[$section] = substr($parts[1], 0, hexdec($parts[0]));


### PR DESCRIPTION
## Summary
- introduce `IcapMethod` and `IcapBodySection` enums
- drop method/section constants from `IcapProtocolConstants`
- update `IcapClient`, `IcapRequestFormatter` and `IcapResponseParser` to use the enums

## Testing
- `composer install` *(fails: ext-dom missing)*
- `vendor/bin/phpunit --version` *(fails: command not found as dependencies not installed)*
