### PR TITLE
Update PHP requirement to 8.2

### DIFF
--- a/Documentation/Architekturdokumentation/README.md
+++ b/Documentation/Architekturdokumentation/README.md
@@ -16,7 +16,7 @@ Diese Bibliothek stellt einen PHP-Client für das **Internet Content Adaptation 
 
 ## 2. Randbedingungen
 ### Technisch
-- Benötigt **PHP 7.4** oder neuer.
+- Benötigt **PHP 8.2** oder neuer.
 - Distribution und Autoloading erfolgen über **Composer**.
 
 ### Organisatorisch

--- a/Documentation/Entwicklerdokumentation/README.md
+++ b/Documentation/Entwicklerdokumentation/README.md
@@ -9,7 +9,7 @@ Eine robuste, moderne und testbare PHP-Implementierung eines ICAP-Clients. Diese
 - [README.md](../../README.md)
 
 ### Tools, Frameworks und Libraries
-- PHP (>=7.4)
+- PHP (>=8.2)
 - Composer
 - PHPUnit
 

--- a/Documentation/Loesungsdokumentation/README.md
+++ b/Documentation/Loesungsdokumentation/README.md
@@ -12,7 +12,7 @@
 ## B. Softwarearchitektur
 
 ### Technologiestack
-- PHP (>=7.4)
+- PHP (>=8.2)
 - Composer
 
 ### Lösungsaufbau
@@ -35,7 +35,7 @@ Die Bibliothek selbst bildet die Drittanbieterlösung. Zusätzlich wird ein exte
 ## C. Bereitstellung der Lösung
 
 ### Installationsvorbereitungen
-- **Prerequisites (Software):** PHP >= 7.4, Composer.
+- **Prerequisites (Software):** PHP >= 8.2, Composer.
 - **Freischaltungen:** Ausgehende Firewall-Freigabe vom Host zum ICAP-Server auf dem konfigurierten Port (Standard 1344).
 - **Datenbanken:** Nicht erforderlich.
 - **Zertifikate:**

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         }
     ],
     "require": {
-        "php": ">=8.2"
+        "php": ">=8.2",
+        "ext-sockets": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^10"


### PR DESCRIPTION
## Summary
- require PHP >=8.2 and sockets extension
- update documentation for PHP 8.2

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter`
- `composer test` *(fails: missing dom, xml, xmlwriter extensions)*
