### PR TITLE
Update exception namespaces in tests

### DIFF
--- a/tests/IcapClientErrorHandlingTest.php
+++ b/tests/IcapClientErrorHandlingTest.php
@@ -60,7 +60,7 @@ class IcapClientErrorHandlingTest extends TestCase
     {
         $transport = new IcapTransport('icap.test', 1344, new FailingSocketClient());
         $client = new IcapClient('icap.test', 1344, $transport);
-        $this->expectException(\IcapClient\Exception\IcapConnectionException::class);
+        $this->expectException(\Ndrstmr\Icap\Exception\IcapConnectionException::class);
         $client->options('example');
     }
 
@@ -69,7 +69,7 @@ class IcapClientErrorHandlingTest extends TestCase
         $socket = new InvalidResponseSocketClient(['BAD DATA', '']);
         $transport = new IcapTransport('icap.test', 1344, $socket);
         $client = new IcapClient('icap.test', 1344, $transport);
-        $this->expectException(\IcapClient\Exception\IcapParseException::class);
+        $this->expectException(\Ndrstmr\Icap\Exception\IcapParseException::class);
         $client->options('example');
     }
 
@@ -79,7 +79,7 @@ class IcapClientErrorHandlingTest extends TestCase
         $transport = new IcapTransport('icap.test', 1344, $socket);
         $transport->setReadTimeout(0.1);
         $client = new IcapClient('icap.test', 1344, $transport);
-        $this->expectException(\IcapClient\Exception\IcapTimeoutException::class);
+        $this->expectException(\Ndrstmr\Icap\Exception\IcapTimeoutException::class);
         $client->options('example');
     }
 }

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -45,7 +45,7 @@ class IcapClientTest extends TestCase
 
         $transport = new IcapTransport('icap.test', 1344, new PhpSocketClient());
         $client = new IcapClient('icap.test', 1344, $transport);
-        $ref = new ReflectionClass($client);
+        $ref = new \ReflectionClass($client);
         $method = $ref->getMethod('parseResponse');
         $method->setAccessible(true);
         $result = $method->invoke($client, $response);
@@ -76,11 +76,11 @@ class IcapClientTest extends TestCase
     {
         $transport = new IcapTransport('icap.test', 1344, new PhpSocketClient());
         $client = new IcapClient('icap.test', 1344, $transport);
-        $ref = new ReflectionClass($client);
+        $ref = new \ReflectionClass($client);
         $method = $ref->getMethod('readFile');
         $method->setAccessible(true);
 
-        $this->expectException(\IcapClient\Exception\IcapFileException::class);
+        $this->expectException(\Ndrstmr\Icap\Exception\IcapFileException::class);
         @$method->invoke($client, '/does/not/exist');
     }
 }

--- a/tests/IcapResponseParserTest.php
+++ b/tests/IcapResponseParserTest.php
@@ -53,7 +53,7 @@ class IcapResponseParserTest extends TestCase
     public function testInvalidResponseThrowsException()
     {
         $parser = new IcapResponseParser();
-        $this->expectException(\IcapClient\Exception\IcapParseException::class);
+        $this->expectException(\Ndrstmr\Icap\Exception\IcapParseException::class);
         $parser->parse('BAD');
     }
 }


### PR DESCRIPTION
## Summary
- update FQCN references for Exception classes in tests
- adjust ReflectionClass usages for PHP namespaces

## Testing
- `vendor/bin/phpunit`
