### PR TITLE
Update namespace in README usage snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ composer require nathan242/php-icap-client
 ## Basic Usage
 
 ```php
-use IcapClient\IcapClient;
+use Ndrstmr\Icap\IcapClient;
 
 $icap = new IcapClient('127.0.0.1', 13440);
 $result = $icap->options('example');


### PR DESCRIPTION
## Summary
- update README to use `Ndrstmr\Icap\IcapClient` in usage snippet

## Testing
- `composer install`
- `vendor/bin/phpunit`
