### PR TITLE
Add TLS connection and header validation

### DIFF
--- a/src/IcapClientFactory.php
+++ b/src/IcapClientFactory.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Ndrstmr\Icap\Socket\PhpSocketClient;
+use Ndrstmr\Icap\Socket\TlsSocketConnection;
+use Ndrstmr\Icap\Transport\IcapTransport;
+
+/**
+ * Factory for creating ICAP clients with optional TLS support.
+ */
+final class IcapClientFactory
+{
+    public static function create(string $host, int $port, bool $tls = false): IcapClient
+    {
+        $connection = $tls ? new TlsSocketConnection() : new PhpSocketClient();
+        $transport = new IcapTransport($host, $port, $connection);
+
+        return new IcapClient($host, $port, $transport);
+    }
+}

--- a/src/IcapRequestFormatter.php
+++ b/src/IcapRequestFormatter.php
@@ -82,8 +82,9 @@ class IcapRequestFormatter
         $result = "{$request->method} icap://{$request->host}/{$request->service} " .
             IcapProtocolConstants::PROTOCOL_PREFIX . IcapProtocolConstants::PROTOCOL_VERSION . "\r\n";
         foreach ($headers as $header => $value) {
+            $sanitizedHeader = str_replace(["\r", "\n"], '', $header);
             $sanitizedValue = str_replace(["\r", "\n"], '', $value);
-            $result .= "{$header}: {$sanitizedValue}\r\n";
+            $result .= "{$sanitizedHeader}: {$sanitizedValue}\r\n";
         }
 
         $result .= "\r\n";
@@ -176,8 +177,9 @@ class IcapRequestFormatter
             IcapProtocolConstants::PROTOCOL_PREFIX . IcapProtocolConstants::PROTOCOL_VERSION . "\r\n";
         $headerString = '';
         foreach ($headers as $header => $value) {
+            $sanitizedHeader = str_replace(["\r", "\n"], '', $header);
             $sanitizedValue = str_replace(["\r", "\n"], '', $value);
-            $headerString .= "{$header}: {$sanitizedValue}\r\n";
+            $headerString .= "{$sanitizedHeader}: {$sanitizedValue}\r\n";
         }
 
         yield $requestLine . $headerString . "\r\n" . $prefixData;

--- a/src/Socket/IcapConnectionInterface.php
+++ b/src/Socket/IcapConnectionInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Socket;
+
+/**
+ * Interface for ICAP socket connections.
+ */
+interface IcapConnectionInterface extends SocketClientInterface
+{
+}

--- a/src/Socket/PhpSocketClient.php
+++ b/src/Socket/PhpSocketClient.php
@@ -8,7 +8,7 @@ use Socket;
 /**
  * Socket implementation using PHP's socket extension.
  */
-class PhpSocketClient implements SocketClientInterface
+class PhpSocketClient implements SocketClientInterface, IcapConnectionInterface
 {
     private ?Socket $socket = null;
 

--- a/src/Socket/TlsSocketConnection.php
+++ b/src/Socket/TlsSocketConnection.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Socket;
+
+/**
+ * Socket implementation using TLS streams via stream_socket_client().
+ */
+class TlsSocketConnection implements SocketClientInterface, IcapConnectionInterface
+{
+    private $stream = null;
+    private float $readTimeout;
+    private float $writeTimeout;
+    private int $lastError = 0;
+
+    public function __construct(float $readTimeout = 0.0, float $writeTimeout = 0.0)
+    {
+        $this->readTimeout = $readTimeout;
+        $this->writeTimeout = $writeTimeout;
+    }
+
+    public function connect(string $host, int $port): bool
+    {
+        $context = stream_context_create([
+            'ssl' => [
+                'verify_peer' => false,
+                'verify_peer_name' => false,
+                'allow_self_signed' => true,
+            ],
+        ]);
+        $uri = "tls://{$host}:{$port}";
+        $this->stream = @stream_socket_client($uri, $errno, $errstr, $this->writeTimeout, STREAM_CLIENT_CONNECT, $context);
+        if ($this->stream === false) {
+            $this->lastError = $errno;
+            $this->stream = null;
+            return false;
+        }
+        stream_set_timeout($this->stream, (int)$this->readTimeout, (int)(($this->readTimeout - (int)$this->readTimeout) * 1_000_000));
+        return true;
+    }
+
+    public function write(string $data): int
+    {
+        if (!is_resource($this->stream)) {
+            return 0;
+        }
+        $result = @fwrite($this->stream, $data);
+        if ($result === false) {
+            $this->lastError = 1;
+            return 0;
+        }
+        return $result;
+    }
+
+    public function read(int $length): string
+    {
+        if (!is_resource($this->stream)) {
+            return '';
+        }
+        $data = @fread($this->stream, $length);
+        if ($data === false) {
+            $this->lastError = 1;
+            return '';
+        }
+        return $data;
+    }
+
+    public function disconnect(): void
+    {
+        if (is_resource($this->stream)) {
+            fclose($this->stream);
+        }
+        $this->stream = null;
+    }
+
+    public function getLastError(): int
+    {
+        return $this->lastError;
+    }
+
+    public function setReadTimeout(float $timeout): void
+    {
+        $this->readTimeout = $timeout;
+        if (is_resource($this->stream)) {
+            stream_set_timeout($this->stream, (int)$timeout, (int)(($timeout - (int)$timeout) * 1_000_000));
+        }
+    }
+
+    public function getReadTimeout(): float
+    {
+        return $this->readTimeout;
+    }
+
+    public function setWriteTimeout(float $timeout): void
+    {
+        $this->writeTimeout = $timeout;
+    }
+
+    public function getWriteTimeout(): float
+    {
+        return $this->writeTimeout;
+    }
+
+    public function waitForData(float $timeout): bool
+    {
+        if (!is_resource($this->stream)) {
+            return false;
+        }
+        $read = [$this->stream];
+        $write = null;
+        $except = null;
+        $sec = (int)$timeout;
+        $usec = (int)(($timeout - $sec) * 1_000_000);
+        $result = @stream_select($read, $write, $except, $sec, $usec);
+        if ($result === false) {
+            return false;
+        }
+        return $result > 0;
+    }
+}

--- a/src/Transport/IcapTransport.php
+++ b/src/Transport/IcapTransport.php
@@ -7,16 +7,16 @@ use Ndrstmr\Icap\Exception\IcapClientException;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
 use Ndrstmr\Icap\Exception\IcapTimeoutException;
 use Ndrstmr\Icap\Socket\PhpSocketClient;
-use Ndrstmr\Icap\Socket\SocketClientInterface;
+use Ndrstmr\Icap\Socket\IcapConnectionInterface;
 
 /**
- * Default transport implementation using {@link SocketClientInterface}.
+ * Default transport implementation using {@link IcapConnectionInterface}.
  */
 class IcapTransport implements TransportInterface
 {
     private string $host;
     private int $port;
-    private SocketClientInterface $socketClient;
+    private IcapConnectionInterface $socketClient;
 
     private bool $persistentConnection = false;
     private bool $connected = false;
@@ -25,7 +25,7 @@ class IcapTransport implements TransportInterface
     /** @var int Size of read buffer in bytes */
     private int $readBufferSize = 8192;
 
-    public function __construct(string $host, int $port, SocketClientInterface $socketClient = null)
+    public function __construct(string $host, int $port, IcapConnectionInterface $socketClient = null)
     {
         $this->host = $host;
         $this->port = $port;

--- a/tests/IcapClientErrorHandlingTest.php
+++ b/tests/IcapClientErrorHandlingTest.php
@@ -2,11 +2,11 @@
 namespace Ndrstmr\Icap\Tests;
 
 use Ndrstmr\Icap\IcapClient;
-use Ndrstmr\Icap\Socket\SocketClientInterface;
+use Ndrstmr\Icap\Socket\IcapConnectionInterface;
 use Ndrstmr\Icap\Transport\IcapTransport;
 use PHPUnit\Framework\TestCase;
 
-class FailingSocketClient implements SocketClientInterface
+class FailingSocketClient implements IcapConnectionInterface
 {
     public function connect(string $host, int $port): bool { return false; }
     public function write(string $data): int { return 0; }
@@ -20,7 +20,7 @@ class FailingSocketClient implements SocketClientInterface
     public function waitForData(float $timeout): bool { return false; }
 }
 
-class InvalidResponseSocketClient implements SocketClientInterface
+class InvalidResponseSocketClient implements IcapConnectionInterface
 {
     private array $responses;
     public function __construct(array $responses) { $this->responses = $responses; }
@@ -36,7 +36,7 @@ class InvalidResponseSocketClient implements SocketClientInterface
     public function waitForData(float $timeout): bool { return true; }
 }
 
-class TimeoutSocketClient implements SocketClientInterface
+class TimeoutSocketClient implements IcapConnectionInterface
 {
     private float $readTimeout = 0.0;
     public function connect(string $host, int $port): bool { return true; }

--- a/tests/IcapClientFactoryTest.php
+++ b/tests/IcapClientFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace Ndrstmr\Icap\Tests;
+
+use Ndrstmr\Icap\IcapClientFactory;
+use Ndrstmr\Icap\Socket\TlsSocketConnection;
+use Ndrstmr\Icap\Socket\PhpSocketClient;
+use PHPUnit\Framework\TestCase;
+
+class IcapClientFactoryTest extends TestCase
+{
+    public function testCreateDefaultReturnsPhpSocketClient()
+    {
+        $client = IcapClientFactory::create('icap.test', 1344);
+        $ref = new \ReflectionClass($client);
+        $prop = $ref->getProperty('transport');
+        $prop->setAccessible(true);
+        $transport = $prop->getValue($client);
+        $refTrans = new \ReflectionClass($transport);
+        $sprop = $refTrans->getProperty('socketClient');
+        $sprop->setAccessible(true);
+        $socket = $sprop->getValue($transport);
+        $this->assertInstanceOf(PhpSocketClient::class, $socket);
+    }
+
+    public function testCreateWithTlsReturnsTlsSocketConnection()
+    {
+        $client = IcapClientFactory::create('icap.test', 1344, true);
+        $ref = new \ReflectionClass($client);
+        $prop = $ref->getProperty('transport');
+        $prop->setAccessible(true);
+        $transport = $prop->getValue($client);
+        $refTrans = new \ReflectionClass($transport);
+        $sprop = $refTrans->getProperty('socketClient');
+        $sprop->setAccessible(true);
+        $socket = $sprop->getValue($transport);
+        $this->assertInstanceOf(TlsSocketConnection::class, $socket);
+    }
+}

--- a/tests/IcapRequestFormatterTest.php
+++ b/tests/IcapRequestFormatterTest.php
@@ -53,6 +53,23 @@ class IcapRequestFormatterTest extends TestCase
         $this->assertStringNotContainsString("\nInjected:", $result);
     }
 
+    public function testHeaderNameInjectionIsSanitized()
+    {
+        $request = new IcapRequest(
+            'OPTIONS',
+            'icap.test',
+            'example',
+            [
+                "X-Te\nst" => 'bar'
+            ]
+        );
+
+        $formatter = new IcapRequestFormatter();
+        $result = $formatter->format($request);
+
+        $this->assertStringContainsString("X-Test: bar\r\n", $result);
+    }
+
     public function testFormatIterableMatchesFormat()
     {
         $request = new IcapRequest(

--- a/tests/IcapTransportTest.php
+++ b/tests/IcapTransportTest.php
@@ -2,11 +2,11 @@
 namespace Ndrstmr\Icap\Tests;
 
 use Ndrstmr\Icap\Transport\IcapTransport;
-use Ndrstmr\Icap\Socket\SocketClientInterface;
+use Ndrstmr\Icap\Socket\IcapConnectionInterface;
 use Ndrstmr\Icap\Exception\IcapTimeoutException;
 use PHPUnit\Framework\TestCase;
 
-class StreamingSocketClient implements SocketClientInterface
+class StreamingSocketClient implements IcapConnectionInterface
 {
     private array $chunks;
     private float $delay;


### PR DESCRIPTION
## Summary
- sanitize header names to prevent CRLF injection
- introduce `IcapConnectionInterface` implemented by new `TlsSocketConnection`
- update `IcapTransport` to use the new interface
- provide `IcapClientFactory` for optional TLS connection
- cover factory and header sanitation with tests

## Testing
- `composer install`
- `vendor/bin/phpunit`
