### PR TITLE
Add TLS verification options

### DIFF
--- a/Documentation/Entwicklerdokumentation/README.md
+++ b/Documentation/Entwicklerdokumentation/README.md
@@ -73,3 +73,7 @@ Eigene Exception-Klassen decken typische Fehler ab:
 
 ### Abhängigkeitsinjektion
 Über das `SocketClientInterface` lassen sich unterschiedliche Socket-Implementierungen verwenden. Dadurch ist der Transport austauschbar und Tests können mit Mock-Implementierungen arbeiten.
+
+### TLS-Optionen
+
+`TlsSocketConnection` erlaubt seit Version 1.1 die Steuerung von `verify_peer` und `verify_peer_name` über den Konstruktor. Beide Parameter sind standardmäßig aktiviert, um Man-in-the-Middle-Angriffe zu verhindern. Bei Bedarf können sie auf `false` gesetzt werden, etwa für Testumgebungen mit selbstsignierten Zertifikaten.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ data is available (for example using `socket_set_nonblock()` or `stream_select`)
 The provided `PhpSocketClient` remains blocking by default but can be swapped
 out for a non‑blocking variant.
 
+### TLS Verification
+
+`TlsSocketConnection` verifies the server certificate and host name by default.
+You can override this behaviour by passing boolean flags to its constructor:
+
+```php
+use Ndrstmr\Icap\Socket\TlsSocketConnection;
+
+$socket = new TlsSocketConnection(0.0, 0.0, false, false); // disable checks
+```
+
+Both flags default to `true` to guard against man‑in‑the‑middle attacks.
+
 ## Running Tests
 
 Execute the following command to run the test suite:

--- a/src/Socket/TlsSocketConnection.php
+++ b/src/Socket/TlsSocketConnection.php
@@ -12,20 +12,24 @@ class TlsSocketConnection implements SocketClientInterface, IcapConnectionInterf
     private float $readTimeout;
     private float $writeTimeout;
     private int $lastError = 0;
+    private bool $verifyPeer;
+    private bool $verifyPeerName;
 
-    public function __construct(float $readTimeout = 0.0, float $writeTimeout = 0.0)
+    public function __construct(float $readTimeout = 0.0, float $writeTimeout = 0.0, bool $verifyPeer = true, bool $verifyPeerName = true)
     {
         $this->readTimeout = $readTimeout;
         $this->writeTimeout = $writeTimeout;
+        $this->verifyPeer = $verifyPeer;
+        $this->verifyPeerName = $verifyPeerName;
     }
 
     public function connect(string $host, int $port): bool
     {
         $context = stream_context_create([
             'ssl' => [
-                'verify_peer' => false,
-                'verify_peer_name' => false,
-                'allow_self_signed' => true,
+                'verify_peer' => $this->verifyPeer,
+                'verify_peer_name' => $this->verifyPeerName,
+                'allow_self_signed' => !$this->verifyPeer,
             ],
         ]);
         $uri = "tls://{$host}:{$port}";


### PR DESCRIPTION
## Summary
- allow toggling TLS peer checks in `TlsSocketConnection`
- document the new parameters in the user README
- mention TLS options in the developer docs

## Testing
- `composer install --ignore-platform-req=ext-dom --ignore-platform-req=ext-xml --ignore-platform-req=ext-xmlwriter` *(fails: PHPUnit requires extensions)*
