### PR TITLE
Expose configurable client defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ The transport reads data in chunks controlled by `setReadBufferSize()`. The
 default buffer size is 8192 bytes. Reduce this value when working with
 non‑blocking socket clients to limit how much data is read at a time.
 
+### Client Configuration
+
+`IcapClientFactory::create()` accepts an optional `IcapClientConfig` allowing
+you to override defaults like the user agent string or maximum response size:
+
+```php
+use Ndrstmr\Icap\IcapClientFactory;
+use Ndrstmr\Icap\IcapClientConfig;
+
+$config = new IcapClientConfig(
+    maxResponseSize: 2097152,
+    userAgent: 'MyApp/1.0'
+);
+$icap = IcapClientFactory::create('icap.test', 1344, false, $config);
+```
+
 ### Non‑blocking Sockets
 
 Custom implementations of `SocketClientInterface` may return immediately when no

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -184,6 +184,10 @@ class IcapClient
      */
     public function getRequest(string $method, string $service, array $body = [], array $headers = []): string
     {
+        if (!isset($headers[IcapProtocolConstants::HEADER_USER_AGENT])) {
+            $headers[IcapProtocolConstants::HEADER_USER_AGENT] = $this->userAgent;
+        }
+
         $icapRequest = new IcapRequest($method, $this->host, $service, $headers, $body);
 
         return $this->requestFormatter->format($icapRequest);
@@ -195,6 +199,10 @@ class IcapClient
      */
     public function getRequestIterable(string $method, string $service, array $body = [], array $headers = []): iterable
     {
+        if (!isset($headers[IcapProtocolConstants::HEADER_USER_AGENT])) {
+            $headers[IcapProtocolConstants::HEADER_USER_AGENT] = $this->userAgent;
+        }
+
         $icapRequest = new IcapRequest($method, $this->host, $service, $headers, $body);
 
         return $this->requestFormatter->formatIterable($icapRequest);

--- a/src/IcapClientConfig.php
+++ b/src/IcapClientConfig.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+/**
+ * Configuration object for IcapClient instances.
+ */
+class IcapClientConfig
+{
+    public int $maxResponseSize;
+    public string $userAgent;
+    public float $readTimeout;
+    public int $readBufferSize;
+    public bool $persistentConnection;
+
+    public function __construct(
+        int $maxResponseSize = 10485760,
+        string $userAgent = 'PHP-ICAP-CLIENT/0.5.0',
+        float $readTimeout = 5.0,
+        int $readBufferSize = 8192,
+        bool $persistentConnection = false
+    ) {
+        $this->maxResponseSize = $maxResponseSize;
+        $this->userAgent = $userAgent;
+        $this->readTimeout = $readTimeout;
+        $this->readBufferSize = $readBufferSize;
+        $this->persistentConnection = $persistentConnection;
+    }
+}

--- a/src/IcapClientFactory.php
+++ b/src/IcapClientFactory.php
@@ -12,11 +12,25 @@ use Ndrstmr\Icap\Transport\IcapTransport;
  */
 final class IcapClientFactory
 {
-    public static function create(string $host, int $port, bool $tls = false): IcapClient
+    public static function create(
+        string $host,
+        int $port,
+        bool $tls = false,
+        ?IcapClientConfig $config = null
+    ): IcapClient
     {
         $connection = $tls ? new TlsSocketConnection() : new PhpSocketClient();
         $transport = new IcapTransport($host, $port, $connection);
 
-        return new IcapClient($host, $port, $transport);
+        $config ??= new IcapClientConfig();
+        $transport->setMaxResponseSize($config->maxResponseSize);
+        $transport->setReadTimeout($config->readTimeout);
+        $transport->setReadBufferSize($config->readBufferSize);
+        $transport->setPersistentConnection($config->persistentConnection);
+
+        $client = new IcapClient($host, $port, $transport);
+        $client->setUserAgent($config->userAgent);
+
+        return $client;
     }
 }

--- a/tests/IcapClientFactoryTest.php
+++ b/tests/IcapClientFactoryTest.php
@@ -2,6 +2,7 @@
 namespace Ndrstmr\Icap\Tests;
 
 use Ndrstmr\Icap\IcapClientFactory;
+use Ndrstmr\Icap\IcapClientConfig;
 use Ndrstmr\Icap\Socket\TlsSocketConnection;
 use Ndrstmr\Icap\Socket\PhpSocketClient;
 use PHPUnit\Framework\TestCase;
@@ -34,5 +35,17 @@ class IcapClientFactoryTest extends TestCase
         $sprop->setAccessible(true);
         $socket = $sprop->getValue($transport);
         $this->assertInstanceOf(TlsSocketConnection::class, $socket);
+    }
+
+    public function testCreateAppliesConfiguration()
+    {
+        $config = new IcapClientConfig(1, 'TEST-UA', 1.5, 1024, true);
+        $client = IcapClientFactory::create('icap.test', 1344, false, $config);
+
+        $this->assertSame('TEST-UA', $client->getUserAgent());
+        $this->assertSame(1, $client->getMaxResponseSize());
+        $this->assertSame(1.5, $client->getReadTimeout());
+        $this->assertSame(1024, $client->getReadBufferSize());
+        $this->assertTrue($client->isPersistentConnection());
     }
 }


### PR DESCRIPTION
## Summary
- add `IcapClientConfig` for configuring defaults
- allow factory to apply configuration
- inject user agent header from client instance
- document optional configuration
- test configuration handling

## Testing
- `composer install --ignore-platform-reqs` *(fails: Required package "psr/http-client" is not present in the lock file)*
- `composer update --no-interaction --ignore-platform-reqs`
- `vendor/bin/phpunit` *(fails: PHPUnit requires the "dom" extension)*
